### PR TITLE
Don't leave postgres transactions open on errors

### DIFF
--- a/ptero_workflow/implementation/backend.py
+++ b/ptero_workflow/implementation/backend.py
@@ -76,4 +76,4 @@ class Backend(object):
         node.handle_event(event_type, body_data, query_string_data)
 
     def cleanup(self):
-        pass
+        self.session.rollback()


### PR DESCRIPTION
I'm not sure where we weren't rolling back, but it was causing significant performance degradation.  This is just a catchall to protect the system from this kind of resource leak.
