### PR TITLE
Bring workflow's JSON workflow representation into agreement with perl-sdk's representation

### DIFF
--- a/ptero_workflow/api/v1/schemas/post_workflow.json
+++ b/ptero_workflow/api/v1/schemas/post_workflow.json
@@ -43,7 +43,7 @@
 
         "method": { "oneOf": [
             { "$ref": "#/definitions/workflow" },
-            { "$ref": "#/definitions/execution" }
+            { "$ref": "#/definitions/shellCommandMethod" }
         ]},
 
         "workflow": {
@@ -56,14 +56,17 @@
             "additionalProperties": false
         },
 
-        "execution": {
+        "shellCommandMethod": {
             "type": "object",
             "properties": {
                 "name": { "$ref": "#/definitions/name" },
                 "parameters": { "type": "object" },
-                "service": { "$ref": "#/definitions/name" }
+                "service": {
+                    "type": "string",
+                    "pattern": "^ShellCommand$"
+                }
             },
-            "required": ["service"],
+            "required": ["name", "parameters", "service"],
             "additionalProperties": false
         },
 

--- a/ptero_workflow/api/v1/schemas/post_workflow.json
+++ b/ptero_workflow/api/v1/schemas/post_workflow.json
@@ -63,7 +63,7 @@
                 "parameters": { "type": "object" },
                 "service": {
                     "type": "string",
-                    "pattern": "^ShellCommand$"
+                    "pattern": "^shell_command$"
                 }
             },
             "required": ["name", "parameters", "service"],

--- a/ptero_workflow/api/v1/schemas/post_workflow.json
+++ b/ptero_workflow/api/v1/schemas/post_workflow.json
@@ -6,10 +6,10 @@
     "properties": {
         "inputs": { "type": "object" },
         "tasks": { "$ref": "#/definitions/taskDictionary" },
-        "edges": { "$ref": "#/definitions/edgeList" },
+        "links": { "$ref": "#/definitions/linkList" },
         "parallelBy": { "$ref": "#/definitions/name" }
     },
-    "required": ["inputs", "tasks", "edges"],
+    "required": ["inputs", "tasks", "links"],
     "additionalProperties": false,
 
     "definitions": {
@@ -50,9 +50,9 @@
             "type": "object",
             "properties": {
                 "tasks": { "$ref": "#/definitions/taskDictionary" },
-                "edges": { "$ref": "#/definitions/edgeList" }
+                "links": { "$ref": "#/definitions/linkList" }
             },
-            "required": ["tasks", "edges"],
+            "required": ["tasks", "links"],
             "additionalProperties": false
         },
 
@@ -67,13 +67,13 @@
             "additionalProperties": false
         },
 
-        "edgeList": {
+        "linkList": {
             "type": "array",
             "minItems": 2,
-            "items": { "$ref": "#/definitions/edge" }
+            "items": { "$ref": "#/definitions/link" }
         },
 
-        "edge": {
+        "link": {
             "type": "object",
             "properties": {
                 "destination": { "$ref": "#/definitions/name" },

--- a/ptero_workflow/api/v1/schemas/post_workflow.json
+++ b/ptero_workflow/api/v1/schemas/post_workflow.json
@@ -77,7 +77,7 @@
                 "parameters": { "type": "object" },
                 "service": {
                     "type": "string",
-                    "pattern": "^shell_command$"
+                    "pattern": "^shell-command$"
                 }
             },
             "required": ["name", "parameters", "service"],

--- a/ptero_workflow/api/v1/schemas/post_workflow.json
+++ b/ptero_workflow/api/v1/schemas/post_workflow.json
@@ -42,11 +42,25 @@
         },
 
         "method": { "oneOf": [
-            { "$ref": "#/definitions/workflow" },
+            { "$ref": "#/definitions/workflowMethod" },
             { "$ref": "#/definitions/shellCommandMethod" }
         ]},
 
-        "workflow": {
+        "workflowMethod": {
+            "type": "object",
+            "properties": {
+                "name": { "$ref": "#/definitions/name" },
+                "parameters": { "$ref": "#/definitions/workflowParameters" },
+                "service": {
+                    "type": "string",
+                    "pattern": "^workflow$"
+                }
+            },
+            "required": ["name", "parameters", "service"],
+            "additionalProperties": false
+        },
+
+        "workflowParameters": {
             "type": "object",
             "properties": {
                 "tasks": { "$ref": "#/definitions/taskDictionary" },

--- a/ptero_workflow/implementation/backend.py
+++ b/ptero_workflow/implementation/backend.py
@@ -32,8 +32,12 @@ class Backend(object):
         root_data = {
             'methods': [
                 {
-                    'tasks': workflow_data['tasks'],
-                    'links': workflow_data['links'],
+                    'name': 'root',
+                    'parameters': {
+                        'tasks': workflow_data['tasks'],
+                        'links': workflow_data['links'],
+                    },
+                    'service': 'workflow',
                 },
             ],
             'parallelBy': workflow_data.get('parallelBy'),

--- a/ptero_workflow/implementation/backend.py
+++ b/ptero_workflow/implementation/backend.py
@@ -33,7 +33,7 @@ class Backend(object):
             'methods': [
                 {
                     'tasks': workflow_data['tasks'],
-                    'edges': workflow_data['edges'],
+                    'links': workflow_data['links'],
                 },
             ],
             'parallelBy': workflow_data.get('parallelBy'),
@@ -47,12 +47,12 @@ class Backend(object):
         dummy_output_task = models.InputHolder(name='dummy output task')
         self.session.add(dummy_output_task)
 
-        for edge_data in workflow_data['edges']:
-            if 'output connector' == edge_data['destination']:
-                self.session.add(models.Edge(source_task=workflow.root_task,
-                        source_property=edge_data['destinationProperty'],
+        for link_data in workflow_data['links']:
+            if 'output connector' == link_data['destination']:
+                self.session.add(models.Link(source_task=workflow.root_task,
+                        source_property=link_data['destinationProperty'],
                         destination_task=dummy_output_task,
-                        destination_property=edge_data['destinationProperty']))
+                        destination_property=link_data['destinationProperty']))
 
         self.session.add(workflow)
         self.session.commit()

--- a/ptero_workflow/implementation/models/__init__.py
+++ b/ptero_workflow/implementation/models/__init__.py
@@ -1,5 +1,5 @@
 from .base import *
-from .edge import *
+from .link import *
 from .execution import *
 from .input_source import *
 from .methods import *

--- a/ptero_workflow/implementation/models/link.py
+++ b/ptero_workflow/implementation/models/link.py
@@ -5,14 +5,14 @@ from sqlalchemy.orm import backref, relationship
 import logging
 
 
-__all__ = ['Edge']
+__all__ = ['Link']
 
 
 LOG = logging.getLogger(__file__)
 
 
-class Edge(Base):
-    __tablename__ = 'edge'
+class Link(Base):
+    __tablename__ = 'link'
     __table_args__ = (
         UniqueConstraint('destination_id', 'destination_property'),
     )
@@ -28,11 +28,11 @@ class Edge(Base):
     parallel_by = Column(Boolean, nullable=False, default=False)
 
     source_task = relationship('Task',
-            backref=backref('output_edges'),
+            backref=backref('output_links'),
             foreign_keys=[source_id])
 
     destination_task = relationship('Task',
-            backref=backref('input_edges'),
+            backref=backref('input_links'),
             foreign_keys=[destination_id])
 
     @property

--- a/ptero_workflow/implementation/models/methods/dag.py
+++ b/ptero_workflow/implementation/models/methods/dag.py
@@ -44,7 +44,7 @@ class DAGMethod(Method):
 
             if child.input_tasks:
                 transitions.append({
-                    'inputs': [self._edge_place_name(t, child)
+                    'inputs': [self._link_place_name(t, child)
                         for t in child.input_tasks],
                     'outputs': [child_start_place],
                 })
@@ -52,7 +52,7 @@ class DAGMethod(Method):
             if child.output_tasks:
                 transitions.append({
                     'inputs': [child_success_place],
-                    'outputs': [self._edge_place_name(child, t)
+                    'outputs': [self._link_place_name(child, t)
                         for t in child.output_tasks],
                 })
 
@@ -74,8 +74,8 @@ class DAGMethod(Method):
     def _child_start_place(self, child_name):
         return '%s:%s-start' % (self.unique_name, child_name)
 
-    def _edge_place_name(self, source, destination):
-        return '%s:%s-to-%s-edge' % (self.unique_name, source.unique_name,
+    def _link_place_name(self, source, destination):
+        return '%s:%s-to-%s-link' % (self.unique_name, source.unique_name,
                 destination.unique_name)
 
     @property

--- a/ptero_workflow/implementation/models/methods/shell_command.py
+++ b/ptero_workflow/implementation/models/methods/shell_command.py
@@ -20,7 +20,7 @@ class ShellCommand(Method):
     parameters = Column(JSON, nullable=False)
 
     __mapper_args__ = {
-        'polymorphic_identity': 'ShellCommand',
+        'polymorphic_identity': 'shell_command',
     }
 
     VALID_CALLBACK_TYPES = Method.VALID_CALLBACK_TYPES.union(

--- a/ptero_workflow/implementation/models/methods/shell_command.py
+++ b/ptero_workflow/implementation/models/methods/shell_command.py
@@ -20,7 +20,7 @@ class ShellCommand(Method):
     parameters = Column(JSON, nullable=False)
 
     __mapper_args__ = {
-        'polymorphic_identity': 'shell_command',
+        'polymorphic_identity': 'shell-command',
     }
 
     VALID_CALLBACK_TYPES = Method.VALID_CALLBACK_TYPES.union(

--- a/ptero_workflow/implementation/models/task/task_base.py
+++ b/ptero_workflow/implementation/models/task/task_base.py
@@ -291,11 +291,11 @@ class Task(Base):
 
     @property
     def input_names(self):
-        return [e.destination_property for e in self.input_edges]
+        return [e.destination_property for e in self.input_links]
 
     @property
     def output_names(self):
-        return [e.source_property for e in self.output_edges]
+        return [e.source_property for e in self.output_links]
 
     @classmethod
     def from_dict(cls, type, **kwargs):
@@ -331,7 +331,7 @@ class Task(Base):
 
     @property
     def input_tasks(self):
-        source_ids = set([l.source_id for l in self.input_edges])
+        source_ids = set([l.source_id for l in self.input_links])
         if source_ids:
             s = object_session(self)
             return s.query(Task).filter(Task.id.in_(source_ids)).all()
@@ -340,7 +340,7 @@ class Task(Base):
 
     @property
     def output_tasks(self):
-        destination_ids = set([l.destination_id for l in self.output_edges])
+        destination_ids = set([l.destination_id for l in self.output_links])
         if destination_ids:
             s = object_session(self)
             return s.query(Task).filter(
@@ -389,7 +389,7 @@ class Task(Base):
         else:
             pdepths = parallel_depths
 
-        for e in self.input_edges:
+        for e in self.input_links:
             if e.destination_property == name:
                 return e.source_task.resolve_output_source(session,
                         e.source_property, pdepths)
@@ -399,7 +399,7 @@ class Task(Base):
 
     def create_input_sources(self, session, parallel_depths):
         LOG.debug('Creating input sources for %s', self.name)
-        for e in self.input_edges:
+        for e in self.input_links:
             source_task, source_property, source_parallel_depths = \
                     self.resolve_input_source(session, e.destination_property,
                             parallel_depths)

--- a/ptero_workflow/implementation/models/workflow.py
+++ b/ptero_workflow/implementation/models/workflow.py
@@ -40,11 +40,11 @@ class Workflow(Base):
     start_place_name = 'workflow-start-place'
 
     @property
-    def edges(self):
+    def links(self):
         results = []
 
         for name,task in self.tasks.iteritems():
-            results.extend(task.input_edges)
+            results.extend(task.input_links)
 
         return results
 
@@ -56,11 +56,11 @@ class Workflow(Base):
     def as_dict(self):
         tasks = {name: task.as_dict for name,task in self.tasks.iteritems()
                 if name not in ['input connector', 'output connector']}
-        edges = [l.as_dict for l in self.edges]
+        links = [l.as_dict for l in self.links]
 
         data = {
             'tasks': tasks,
-            'edges': edges,
+            'links': links,
             'inputs': self.root_task.get_inputs(colors=[0], begins=[0]),
         }
         if self.root_task.status is not None:

--- a/ptero_workflow/implementation/tasks.py
+++ b/ptero_workflow/implementation/tasks.py
@@ -40,14 +40,14 @@ def _build_dag_method(data, index, parent_task):
 
     method.children = children
 
-    for edge_data in data['edges']:
-        source = children[edge_data['source']]
-        destination = children[edge_data['destination']]
-        models.Edge(
+    for link_data in data['links']:
+        source = children[link_data['source']]
+        destination = children[link_data['destination']]
+        models.Link(
             destination_task=destination,
-            destination_property=edge_data['destinationProperty'],
+            destination_property=link_data['destinationProperty'],
             source_task=source,
-            source_property=edge_data['sourceProperty'],
+            source_property=link_data['sourceProperty'],
         )
 
     return method
@@ -62,7 +62,7 @@ def create_input_holder(root, inputs, color):
     task = models.InputHolder(name='input_holder')
     task.set_outputs(inputs, color=color, parent_color=None)
     for i in inputs.iterkeys():
-        models.Edge(source_task=task, destination_task=root,
+        models.Link(source_task=task, destination_task=root,
                 source_property=i, destination_property=i)
     return task
 

--- a/tests/api/v1/regression_tests/parallel_by_operation_multiple_inputs/submit.json
+++ b/tests/api/v1/regression_tests/parallel_by_operation_multiple_inputs/submit.json
@@ -31,7 +31,7 @@
         }
     },
 
-    "edges": [
+    "links": [
         {
             "source": "input connector",
             "destination": "intermediate",

--- a/tests/api/v1/regression_tests/parallel_by_operation_multiple_inputs/submit.json
+++ b/tests/api/v1/regression_tests/parallel_by_operation_multiple_inputs/submit.json
@@ -4,7 +4,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -18,7 +18,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/regression_tests/parallel_by_operation_multiple_inputs/submit.json
+++ b/tests/api/v1/regression_tests/parallel_by_operation_multiple_inputs/submit.json
@@ -4,7 +4,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -18,7 +18,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/regression_tests/parallel_by_operation_multiple_outputs/submit.json
+++ b/tests/api/v1/regression_tests/parallel_by_operation_multiple_outputs/submit.json
@@ -45,7 +45,7 @@
         }
     },
 
-    "edges": [
+    "links": [
         {
             "source": "input connector",
             "destination": "start",

--- a/tests/api/v1/regression_tests/parallel_by_operation_multiple_outputs/submit.json
+++ b/tests/api/v1/regression_tests/parallel_by_operation_multiple_outputs/submit.json
@@ -4,7 +4,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -18,7 +18,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -33,7 +33,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/regression_tests/parallel_by_operation_multiple_outputs/submit.json
+++ b/tests/api/v1/regression_tests/parallel_by_operation_multiple_outputs/submit.json
@@ -4,7 +4,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -18,7 +18,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -33,7 +33,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/n_shaped/submit.json
+++ b/tests/api/v1/system_tests/n_shaped/submit.json
@@ -4,7 +4,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -18,7 +18,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -32,7 +32,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -46,7 +46,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/n_shaped/submit.json
+++ b/tests/api/v1/system_tests/n_shaped/submit.json
@@ -58,7 +58,7 @@
         }
     },
 
-    "edges": [
+    "links": [
         {
             "source": "input connector",
             "destination": "A",

--- a/tests/api/v1/system_tests/n_shaped/submit.json
+++ b/tests/api/v1/system_tests/n_shaped/submit.json
@@ -4,7 +4,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -18,7 +18,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -32,7 +32,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -46,7 +46,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/nested/submit.json
+++ b/tests/api/v1/system_tests/nested/submit.json
@@ -33,7 +33,7 @@
                             ]
                         }
                     },
-                    "edges": [
+                    "links": [
                         {
                             "source": "input connector",
                             "destination": "B",
@@ -66,7 +66,7 @@
         }
     },
 
-    "edges": [
+    "links": [
         {
             "source": "input connector",
             "destination": "A",

--- a/tests/api/v1/system_tests/nested/submit.json
+++ b/tests/api/v1/system_tests/nested/submit.json
@@ -4,7 +4,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -24,7 +24,7 @@
                                 "methods": [
                                     {
                                         "name": "execute",
-                                        "service": "shell_command",
+                                        "service": "shell-command",
                                         "parameters": {
                                             "commandLine": ["./echo_command"],
                                             "user": "{{ user }}",
@@ -58,7 +58,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/nested/submit.json
+++ b/tests/api/v1/system_tests/nested/submit.json
@@ -17,36 +17,40 @@
         "Inner": {
             "methods": [
                 {
-                    "tasks": {
-                        "B": {
-                            "methods": [
-                                {
-                                    "name": "execute",
-                                    "service": "shell_command",
-                                    "parameters": {
-                                        "commandLine": ["./echo_command"],
-                                        "user": "{{ user }}",
-                                        "workingDirectory": "{{ workingDirectory }}",
-                                        "environment": {{ environment }}
+                    "name": "some_workflow",
+                    "parameters": {
+                        "tasks": {
+                            "B": {
+                                "methods": [
+                                    {
+                                        "name": "execute",
+                                        "service": "shell_command",
+                                        "parameters": {
+                                            "commandLine": ["./echo_command"],
+                                            "user": "{{ user }}",
+                                            "workingDirectory": "{{ workingDirectory }}",
+                                            "environment": {{ environment }}
+                                        }
                                     }
-                                }
-                            ]
-                        }
-                    },
-                    "links": [
-                        {
-                            "source": "input connector",
-                            "destination": "B",
-                            "sourceProperty": "inner_in_b",
-                            "destinationProperty": "param"
+                                ]
+                            }
                         },
-                        {
-                            "source": "B",
-                            "destination": "output connector",
-                            "sourceProperty": "param",
-                            "destinationProperty": "inner_out_b"
-                        }
-                    ]
+                        "links": [
+                            {
+                                "source": "input connector",
+                                "destination": "B",
+                                "sourceProperty": "inner_in_b",
+                                "destinationProperty": "param"
+                            },
+                            {
+                                "source": "B",
+                                "destination": "output connector",
+                                "sourceProperty": "param",
+                                "destinationProperty": "inner_out_b"
+                            }
+                        ]
+                    },
+                    "service": "workflow"
                 }
             ]
         },

--- a/tests/api/v1/system_tests/nested/submit.json
+++ b/tests/api/v1/system_tests/nested/submit.json
@@ -4,7 +4,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -22,7 +22,7 @@
                             "methods": [
                                 {
                                     "name": "execute",
-                                    "service": "ShellCommand",
+                                    "service": "shell_command",
                                     "parameters": {
                                         "commandLine": ["./echo_command"],
                                         "user": "{{ user }}",
@@ -54,7 +54,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/nested_parallel_by_dag_orthogonal_inputs/submit.json
+++ b/tests/api/v1/system_tests/nested_parallel_by_dag_orthogonal_inputs/submit.json
@@ -12,7 +12,7 @@
                                 "methods": [
                                     {
                                         "name": "execute",
-                                        "service": "shell_command",
+                                        "service": "shell-command",
                                         "parameters": {
                                             "commandLine": ["./echo_command"],
                                             "user": "{{ user }}",

--- a/tests/api/v1/system_tests/nested_parallel_by_dag_orthogonal_inputs/submit.json
+++ b/tests/api/v1/system_tests/nested_parallel_by_dag_orthogonal_inputs/submit.json
@@ -22,7 +22,7 @@
                         }
                     },
 
-                    "edges": [
+                    "links": [
                         {
                             "source": "input connector",
                             "destination": "A",
@@ -55,7 +55,7 @@
         }
     },
 
-    "edges": [
+    "links": [
         {
             "source": "input connector",
             "destination": "Inner",

--- a/tests/api/v1/system_tests/nested_parallel_by_dag_orthogonal_inputs/submit.json
+++ b/tests/api/v1/system_tests/nested_parallel_by_dag_orthogonal_inputs/submit.json
@@ -5,50 +5,54 @@
         "Inner": {
             "methods": [
                 {
-                    "tasks": {
-                        "A": {
-                            "methods": [
-                                {
-                                    "name": "execute",
-                                    "service": "shell_command",
-                                    "parameters": {
-                                        "commandLine": ["./echo_command"],
-                                        "user": "{{ user }}",
-                                        "workingDirectory": "{{ workingDirectory }}",
-                                        "environment": {{ environment }}
+                    "name": "some_workflow",
+                    "parameters": {
+                        "tasks": {
+                            "A": {
+                                "methods": [
+                                    {
+                                        "name": "execute",
+                                        "service": "shell_command",
+                                        "parameters": {
+                                            "commandLine": ["./echo_command"],
+                                            "user": "{{ user }}",
+                                            "workingDirectory": "{{ workingDirectory }}",
+                                            "environment": {{ environment }}
+                                        }
                                     }
-                                }
-                            ]
-                        }
+                                ]
+                            }
+                        },
+
+                        "links": [
+                            {
+                                "source": "input connector",
+                                "destination": "A",
+                                "sourceProperty": "animal_type_in",
+                                "destinationProperty": "animal_type"
+                            },
+                            {
+                                "source": "A",
+                                "destination": "output connector",
+                                "sourceProperty": "animal_type",
+                                "destinationProperty": "animal_type_out"
+                            },
+
+                            {
+                                "source": "input connector",
+                                "destination": "A",
+                                "sourceProperty": "kitten_name_in",
+                                "destinationProperty": "kitten_name"
+                            },
+                            {
+                                "source": "A",
+                                "destination": "output connector",
+                                "sourceProperty": "kitten_name",
+                                "destinationProperty": "kitten_name_out"
+                            }
+                        ]
                     },
-
-                    "links": [
-                        {
-                            "source": "input connector",
-                            "destination": "A",
-                            "sourceProperty": "animal_type_in",
-                            "destinationProperty": "animal_type"
-                        },
-                        {
-                            "source": "A",
-                            "destination": "output connector",
-                            "sourceProperty": "animal_type",
-                            "destinationProperty": "animal_type_out"
-                        },
-
-                        {
-                            "source": "input connector",
-                            "destination": "A",
-                            "sourceProperty": "kitten_name_in",
-                            "destinationProperty": "kitten_name"
-                        },
-                        {
-                            "source": "A",
-                            "destination": "output connector",
-                            "sourceProperty": "kitten_name",
-                            "destinationProperty": "kitten_name_out"
-                        }
-                    ]
+                    "service": "workflow"
                 }
             ],
             "parallelBy": "kitten_name_in"

--- a/tests/api/v1/system_tests/nested_parallel_by_dag_orthogonal_inputs/submit.json
+++ b/tests/api/v1/system_tests/nested_parallel_by_dag_orthogonal_inputs/submit.json
@@ -10,7 +10,7 @@
                             "methods": [
                                 {
                                     "name": "execute",
-                                    "service": "ShellCommand",
+                                    "service": "shell_command",
                                     "parameters": {
                                         "commandLine": ["./echo_command"],
                                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/nested_parallel_by_operation_matrix_inputs/submit.json
+++ b/tests/api/v1/system_tests/nested_parallel_by_operation_matrix_inputs/submit.json
@@ -6,7 +6,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/nested_parallel_by_operation_matrix_inputs/submit.json
+++ b/tests/api/v1/system_tests/nested_parallel_by_operation_matrix_inputs/submit.json
@@ -19,7 +19,7 @@
         }
     },
 
-    "edges": [
+    "links": [
         {
             "source": "input connector",
             "destination": "A",

--- a/tests/api/v1/system_tests/nested_parallel_by_operation_matrix_inputs/submit.json
+++ b/tests/api/v1/system_tests/nested_parallel_by_operation_matrix_inputs/submit.json
@@ -6,7 +6,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/nested_parallel_by_operation_orthogonal_inputs/submit.json
+++ b/tests/api/v1/system_tests/nested_parallel_by_operation_orthogonal_inputs/submit.json
@@ -6,7 +6,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/nested_parallel_by_operation_orthogonal_inputs/submit.json
+++ b/tests/api/v1/system_tests/nested_parallel_by_operation_orthogonal_inputs/submit.json
@@ -19,7 +19,7 @@
         }
     },
 
-    "edges": [
+    "links": [
         {
             "source": "input connector",
             "destination": "A",

--- a/tests/api/v1/system_tests/nested_parallel_by_operation_orthogonal_inputs/submit.json
+++ b/tests/api/v1/system_tests/nested_parallel_by_operation_orthogonal_inputs/submit.json
@@ -6,7 +6,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/parallel_by_dag/submit.json
+++ b/tests/api/v1/system_tests/parallel_by_dag/submit.json
@@ -5,7 +5,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/parallel_by_dag/submit.json
+++ b/tests/api/v1/system_tests/parallel_by_dag/submit.json
@@ -17,7 +17,7 @@
         }
     },
 
-    "edges": [
+    "links": [
         {
             "source": "input connector",
             "destination": "A",

--- a/tests/api/v1/system_tests/parallel_by_dag/submit.json
+++ b/tests/api/v1/system_tests/parallel_by_dag/submit.json
@@ -5,7 +5,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/parallel_by_dag_pass_through/submit.json
+++ b/tests/api/v1/system_tests/parallel_by_dag_pass_through/submit.json
@@ -8,7 +8,7 @@
                             "methods": [
                                 {
                                     "name": "execute",
-                                    "service": "ShellCommand",
+                                    "service": "shell_command",
                                     "parameters": {
                                         "commandLine": ["false"],
                                         "workingDirectory": "{{ workingDirectory }}",
@@ -40,7 +40,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/parallel_by_dag_pass_through/submit.json
+++ b/tests/api/v1/system_tests/parallel_by_dag_pass_through/submit.json
@@ -10,7 +10,7 @@
                                 "methods": [
                                     {
                                         "name": "execute",
-                                        "service": "shell_command",
+                                        "service": "shell-command",
                                         "parameters": {
                                             "commandLine": ["false"],
                                             "workingDirectory": "{{ workingDirectory }}",
@@ -44,7 +44,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/parallel_by_dag_pass_through/submit.json
+++ b/tests/api/v1/system_tests/parallel_by_dag_pass_through/submit.json
@@ -18,7 +18,7 @@
                             ]
                         }
                     },
-                    "edges": [
+                    "links": [
                         {
                             "source": "input connector",
                             "sourceProperty": "constant_param_in",
@@ -52,7 +52,7 @@
         }
     },
 
-    "edges": [
+    "links": [
         {
             "source": "input connector",
             "destination": "Inner",

--- a/tests/api/v1/system_tests/parallel_by_dag_pass_through/submit.json
+++ b/tests/api/v1/system_tests/parallel_by_dag_pass_through/submit.json
@@ -3,35 +3,39 @@
         "Inner": {
             "methods": [
                 {
-                    "tasks": {
-                        "michael": {
-                            "methods": [
-                                {
-                                    "name": "execute",
-                                    "service": "shell_command",
-                                    "parameters": {
-                                        "commandLine": ["false"],
-                                        "workingDirectory": "{{ workingDirectory }}",
-                                        "environment": {{ environment }}
+                    "name": "some_workflow",
+                    "parameters": {
+                        "tasks": {
+                            "michael": {
+                                "methods": [
+                                    {
+                                        "name": "execute",
+                                        "service": "shell_command",
+                                        "parameters": {
+                                            "commandLine": ["false"],
+                                            "workingDirectory": "{{ workingDirectory }}",
+                                            "environment": {{ environment }}
+                                        }
                                     }
-                                }
-                            ]
-                        }
-                    },
-                    "links": [
-                        {
-                            "source": "input connector",
-                            "sourceProperty": "constant_param_in",
-                            "destination": "output connector",
-                            "destinationProperty": "constant_param_out"
+                                ]
+                            }
                         },
-                        {
-                            "source": "input connector",
-                            "sourceProperty": "parallel_param_in",
-                            "destination": "output connector",
-                            "destinationProperty": "parallel_param_out"
-                        }
-                    ]
+                        "links": [
+                            {
+                                "source": "input connector",
+                                "sourceProperty": "constant_param_in",
+                                "destination": "output connector",
+                                "destinationProperty": "constant_param_out"
+                            },
+                            {
+                                "source": "input connector",
+                                "sourceProperty": "parallel_param_in",
+                                "destination": "output connector",
+                                "destinationProperty": "parallel_param_out"
+                            }
+                        ]
+                    },
+                    "service": "workflow"
                 }
             ],
             "parallelBy": "parallel_param_in"

--- a/tests/api/v1/system_tests/parallel_by_nested_dag/submit.json
+++ b/tests/api/v1/system_tests/parallel_by_nested_dag/submit.json
@@ -10,7 +10,7 @@
                                 "methods": [
                                     {
                                         "name": "execute",
-                                        "service": "shell_command",
+                                        "service": "shell-command",
                                         "parameters": {
                                             "commandLine": ["./echo_command"],
                                             "user": "{{ user }}",

--- a/tests/api/v1/system_tests/parallel_by_nested_dag/submit.json
+++ b/tests/api/v1/system_tests/parallel_by_nested_dag/submit.json
@@ -8,7 +8,7 @@
                             "methods": [
                                 {
                                     "name": "execute",
-                                    "service": "ShellCommand",
+                                    "service": "shell_command",
                                     "parameters": {
                                         "commandLine": ["./echo_command"],
                                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/parallel_by_nested_dag/submit.json
+++ b/tests/api/v1/system_tests/parallel_by_nested_dag/submit.json
@@ -20,7 +20,7 @@
                         }
                     },
 
-                    "edges": [
+                    "links": [
                         {
                             "source": "input connector",
                             "destination": "A",
@@ -53,7 +53,7 @@
         }
     },
 
-    "edges": [
+    "links": [
         {
             "source": "input connector",
             "destination": "Inner",

--- a/tests/api/v1/system_tests/parallel_by_nested_dag/submit.json
+++ b/tests/api/v1/system_tests/parallel_by_nested_dag/submit.json
@@ -3,50 +3,54 @@
         "Inner": {
             "methods": [
                 {
-                    "tasks": {
-                        "A": {
-                            "methods": [
-                                {
-                                    "name": "execute",
-                                    "service": "shell_command",
-                                    "parameters": {
-                                        "commandLine": ["./echo_command"],
-                                        "user": "{{ user }}",
-                                        "workingDirectory": "{{ workingDirectory }}",
-                                        "environment": {{ environment }}
+                    "name": "some_workflow",
+                    "parameters": {
+                        "tasks": {
+                            "A": {
+                                "methods": [
+                                    {
+                                        "name": "execute",
+                                        "service": "shell_command",
+                                        "parameters": {
+                                            "commandLine": ["./echo_command"],
+                                            "user": "{{ user }}",
+                                            "workingDirectory": "{{ workingDirectory }}",
+                                            "environment": {{ environment }}
+                                        }
                                     }
-                                }
-                            ]
-                        }
+                                ]
+                            }
+                        },
+
+                        "links": [
+                            {
+                                "source": "input connector",
+                                "destination": "A",
+                                "sourceProperty": "constant_param_in",
+                                "destinationProperty": "constant_param"
+                            },
+                            {
+                                "source": "A",
+                                "destination": "output connector",
+                                "sourceProperty": "constant_param",
+                                "destinationProperty": "constant_param_out"
+                            },
+
+                            {
+                                "source": "input connector",
+                                "destination": "A",
+                                "sourceProperty": "parallel_param_in",
+                                "destinationProperty": "parallel_param"
+                            },
+                            {
+                                "source": "A",
+                                "destination": "output connector",
+                                "sourceProperty": "parallel_param",
+                                "destinationProperty": "parallel_param_out"
+                            }
+                        ]
                     },
-
-                    "links": [
-                        {
-                            "source": "input connector",
-                            "destination": "A",
-                            "sourceProperty": "constant_param_in",
-                            "destinationProperty": "constant_param"
-                        },
-                        {
-                            "source": "A",
-                            "destination": "output connector",
-                            "sourceProperty": "constant_param",
-                            "destinationProperty": "constant_param_out"
-                        },
-
-                        {
-                            "source": "input connector",
-                            "destination": "A",
-                            "sourceProperty": "parallel_param_in",
-                            "destinationProperty": "parallel_param"
-                        },
-                        {
-                            "source": "A",
-                            "destination": "output connector",
-                            "sourceProperty": "parallel_param",
-                            "destinationProperty": "parallel_param_out"
-                        }
-                    ]
+                    "service": "workflow"
                 }
             ],
             "parallelBy": "parallel_param_in"

--- a/tests/api/v1/system_tests/parallel_by_operation/submit.json
+++ b/tests/api/v1/system_tests/parallel_by_operation/submit.json
@@ -17,7 +17,7 @@
         }
     },
 
-    "edges": [
+    "links": [
         {
             "source": "input connector",
             "destination": "A",

--- a/tests/api/v1/system_tests/parallel_by_operation/submit.json
+++ b/tests/api/v1/system_tests/parallel_by_operation/submit.json
@@ -4,7 +4,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/parallel_by_operation/submit.json
+++ b/tests/api/v1/system_tests/parallel_by_operation/submit.json
@@ -4,7 +4,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/sequential_parallel_by/submit.json
+++ b/tests/api/v1/system_tests/sequential_parallel_by/submit.json
@@ -32,7 +32,7 @@
         }
     },
 
-    "edges": [
+    "links": [
         {
             "source": "input connector",
             "destination": "A",

--- a/tests/api/v1/system_tests/sequential_parallel_by/submit.json
+++ b/tests/api/v1/system_tests/sequential_parallel_by/submit.json
@@ -4,7 +4,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -19,7 +19,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/sequential_parallel_by/submit.json
+++ b/tests/api/v1/system_tests/sequential_parallel_by/submit.json
@@ -4,7 +4,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -19,7 +19,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/serial/submit.json
+++ b/tests/api/v1/system_tests/serial/submit.json
@@ -4,7 +4,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -18,7 +18,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -32,7 +32,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/serial/submit.json
+++ b/tests/api/v1/system_tests/serial/submit.json
@@ -44,7 +44,7 @@
         }
     },
 
-    "edges": [
+    "links": [
         {
             "source": "input connector",
             "destination": "A",

--- a/tests/api/v1/system_tests/serial/submit.json
+++ b/tests/api/v1/system_tests/serial/submit.json
@@ -4,7 +4,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -18,7 +18,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -32,7 +32,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/shortcut_failure/submit.json
+++ b/tests/api/v1/system_tests/shortcut_failure/submit.json
@@ -4,7 +4,7 @@
             "methods": [
                 {
                     "name": "shortcut",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["false"],
                         "user": "{{ user }}",
@@ -14,7 +14,7 @@
                 },
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/shortcut_failure/submit.json
+++ b/tests/api/v1/system_tests/shortcut_failure/submit.json
@@ -26,7 +26,7 @@
         }
     },
 
-    "edges": [
+    "links": [
         {
             "source": "input connector",
             "destination": "A",

--- a/tests/api/v1/system_tests/shortcut_failure/submit.json
+++ b/tests/api/v1/system_tests/shortcut_failure/submit.json
@@ -4,7 +4,7 @@
             "methods": [
                 {
                     "name": "shortcut",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["false"],
                         "user": "{{ user }}",
@@ -14,7 +14,7 @@
                 },
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/shortcut_success/submit.json
+++ b/tests/api/v1/system_tests/shortcut_success/submit.json
@@ -26,7 +26,7 @@
         }
     },
 
-    "edges": [
+    "links": [
         {
             "source": "input connector",
             "destination": "A",

--- a/tests/api/v1/system_tests/shortcut_success/submit.json
+++ b/tests/api/v1/system_tests/shortcut_success/submit.json
@@ -4,7 +4,7 @@
             "methods": [
                 {
                     "name": "shortcut",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -14,7 +14,7 @@
                 },
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["false"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/shortcut_success/submit.json
+++ b/tests/api/v1/system_tests/shortcut_success/submit.json
@@ -4,7 +4,7 @@
             "methods": [
                 {
                     "name": "shortcut",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -14,7 +14,7 @@
                 },
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["false"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/single_operation/submit.json
+++ b/tests/api/v1/system_tests/single_operation/submit.json
@@ -16,7 +16,7 @@
         }
     },
 
-    "edges": [
+    "links": [
         {
             "source": "input connector",
             "destination": "A",

--- a/tests/api/v1/system_tests/single_operation/submit.json
+++ b/tests/api/v1/system_tests/single_operation/submit.json
@@ -4,7 +4,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/single_operation/submit.json
+++ b/tests/api/v1/system_tests/single_operation/submit.json
@@ -4,7 +4,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/single_operation_update_command/submit.json
+++ b/tests/api/v1/system_tests/single_operation_update_command/submit.json
@@ -4,7 +4,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./update_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/single_operation_update_command/submit.json
+++ b/tests/api/v1/system_tests/single_operation_update_command/submit.json
@@ -16,7 +16,7 @@
         }
     },
 
-    "edges": [
+    "links": [
         {
             "source": "input connector",
             "destination": "A",

--- a/tests/api/v1/system_tests/single_operation_update_command/submit.json
+++ b/tests/api/v1/system_tests/single_operation_update_command/submit.json
@@ -4,7 +4,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./update_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/split_outputs/submit.json
+++ b/tests/api/v1/system_tests/split_outputs/submit.json
@@ -4,7 +4,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -18,7 +18,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -32,7 +32,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "shell_command",
+                    "service": "shell-command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/system_tests/split_outputs/submit.json
+++ b/tests/api/v1/system_tests/split_outputs/submit.json
@@ -44,7 +44,7 @@
         }
     },
 
-    "edges": [
+    "links": [
         {
             "source": "input connector",
             "destination": "A",

--- a/tests/api/v1/system_tests/split_outputs/submit.json
+++ b/tests/api/v1/system_tests/split_outputs/submit.json
@@ -4,7 +4,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -18,7 +18,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",
@@ -32,7 +32,7 @@
             "methods": [
                 {
                     "name": "execute",
-                    "service": "ShellCommand",
+                    "service": "shell_command",
                     "parameters": {
                         "commandLine": ["./echo_command"],
                         "user": "{{ user }}",

--- a/tests/api/v1/test_post_workflow_failure.py
+++ b/tests/api/v1/test_post_workflow_failure.py
@@ -118,43 +118,47 @@ class NestedInputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
             'Inner': {
                 'methods': [
                     {
-                        'tasks': {
-                            'A': {
-                                'methods': [
-                                    {
-                                        'name': 'execute',
-                                        'service': 'shell_command',
-                                        'parameters': {
-                                            'commandLine': ['cat']
+                        'name': 'some_workflow',
+                        'parameters': {
+                            'tasks': {
+                                'A': {
+                                    'methods': [
+                                        {
+                                            'name': 'execute',
+                                            'service': 'shell_command',
+                                            'parameters': {
+                                                'commandLine': ['cat']
+                                            }
                                         }
-                                    }
-                                ]
-                            },
-                            'input connector': {
-                                'methods': [
-                                    {
-                                        'name': 'execute',
-                                        'service': 'shell_command',
-                                        'parameters': {
-                                            'commandLine': ['cat']
+                                    ]
+                                },
+                                'input connector': {
+                                    'methods': [
+                                        {
+                                            'name': 'execute',
+                                            'service': 'shell_command',
+                                            'parameters': {
+                                                'commandLine': ['cat']
+                                            }
                                         }
-                                    }
-                                ]
+                                    ]
+                                },
                             },
+                            'links': [
+                                {
+                                    'source': 'input connector',
+                                    'destination': 'A',
+                                    'sourceProperty': 'inner_input',
+                                    'destinationProperty': 'param',
+                                }, {
+                                    'source': 'A',
+                                    'destination': 'output connector',
+                                    'sourceProperty': 'result',
+                                    'destinationProperty': 'inner_output',
+                                },
+                            ],
                         },
-                        'links': [
-                            {
-                                'source': 'input connector',
-                                'destination': 'A',
-                                'sourceProperty': 'inner_input',
-                                'destinationProperty': 'param',
-                            }, {
-                                'source': 'A',
-                                'destination': 'output connector',
-                                'sourceProperty': 'result',
-                                'destinationProperty': 'inner_output',
-                            },
-                        ],
+                        'service': 'workflow'
                     },
                 ],
             },
@@ -185,43 +189,47 @@ class NestedOutputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
             'Inner': {
                 'methods': [
                     {
-                        'tasks': {
-                            'A': {
-                                'methods': [
-                                    {
-                                        'name': 'execute',
-                                        'service': 'shell_command',
-                                        'parameters': {
-                                            'commandLine': ['cat']
+                        'name': 'some_workflow',
+                        'parameters': {
+                            'tasks': {
+                                'A': {
+                                    'methods': [
+                                        {
+                                            'name': 'execute',
+                                            'service': 'shell_command',
+                                            'parameters': {
+                                                'commandLine': ['cat']
+                                            }
                                         }
-                                    }
-                                ]
-                            },
-                            'output connector': {
-                                'methods': [
-                                    {
-                                        'name': 'execute',
-                                        'service': 'shell_command',
-                                        'parameters': {
-                                            'commandLine': ['cat']
+                                    ]
+                                },
+                                'output connector': {
+                                    'methods': [
+                                        {
+                                            'name': 'execute',
+                                            'service': 'shell_command',
+                                            'parameters': {
+                                                'commandLine': ['cat']
+                                            }
                                         }
-                                    }
-                                ]
+                                    ]
+                                },
                             },
+                            'links': [
+                                {
+                                    'source': 'input connector',
+                                    'destination': 'A',
+                                    'sourceProperty': 'inner_input',
+                                    'destinationProperty': 'param',
+                                }, {
+                                    'source': 'A',
+                                    'destination': 'output connector',
+                                    'sourceProperty': 'result',
+                                    'destinationProperty': 'inner_output',
+                                },
+                            ],
                         },
-                        'links': [
-                            {
-                                'source': 'input connector',
-                                'destination': 'A',
-                                'sourceProperty': 'inner_input',
-                                'destinationProperty': 'param',
-                            }, {
-                                'source': 'A',
-                                'destination': 'output connector',
-                                'sourceProperty': 'result',
-                                'destinationProperty': 'inner_output',
-                            },
-                        ],
+                        'service': 'workflow',
                     },
                 ],
             },

--- a/tests/api/v1/test_post_workflow_failure.py
+++ b/tests/api/v1/test_post_workflow_failure.py
@@ -28,7 +28,7 @@ class InputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
                 'methods': [
                     {
                         'name': 'execute',
-                        'service': 'shell_command',
+                        'service': 'shell-command',
                         'parameters': {
                             'commandLine': ['cat']
                         }
@@ -39,7 +39,7 @@ class InputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
                 'methods': [
                     {
                         'name': 'execute',
-                        'service': 'shell_command',
+                        'service': 'shell-command',
                         'parameters': {
                             'commandLine': ['cat']
                         }
@@ -74,7 +74,7 @@ class OutputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
                 'methods': [
                     {
                         'name': 'execute',
-                        'service': 'shell_command',
+                        'service': 'shell-command',
                         'parameters': {
                             'commandLine': ['cat']
                         }
@@ -85,7 +85,7 @@ class OutputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
                 'methods': [
                     {
                         'name': 'execute',
-                        'service': 'shell_command',
+                        'service': 'shell-command',
                         'parameters': {
                             'commandLine': ['cat']
                         }
@@ -125,7 +125,7 @@ class NestedInputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
                                     'methods': [
                                         {
                                             'name': 'execute',
-                                            'service': 'shell_command',
+                                            'service': 'shell-command',
                                             'parameters': {
                                                 'commandLine': ['cat']
                                             }
@@ -136,7 +136,7 @@ class NestedInputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
                                     'methods': [
                                         {
                                             'name': 'execute',
-                                            'service': 'shell_command',
+                                            'service': 'shell-command',
                                             'parameters': {
                                                 'commandLine': ['cat']
                                             }
@@ -196,7 +196,7 @@ class NestedOutputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
                                     'methods': [
                                         {
                                             'name': 'execute',
-                                            'service': 'shell_command',
+                                            'service': 'shell-command',
                                             'parameters': {
                                                 'commandLine': ['cat']
                                             }
@@ -207,7 +207,7 @@ class NestedOutputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
                                     'methods': [
                                         {
                                             'name': 'execute',
-                                            'service': 'shell_command',
+                                            'service': 'shell-command',
                                             'parameters': {
                                                 'commandLine': ['cat']
                                             }

--- a/tests/api/v1/test_post_workflow_failure.py
+++ b/tests/api/v1/test_post_workflow_failure.py
@@ -47,7 +47,7 @@ class InputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
                 ]
             },
         },
-        'edges': [
+        'links': [
             {
                 'source': 'input connector',
                 'destination': 'A',
@@ -93,7 +93,7 @@ class OutputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
                 ]
             },
         },
-        'edges': [
+        'links': [
             {
                 'source': 'input connector',
                 'destination': 'A',
@@ -142,7 +142,7 @@ class NestedInputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
                                 ]
                             },
                         },
-                        'edges': [
+                        'links': [
                             {
                                 'source': 'input connector',
                                 'destination': 'A',
@@ -160,7 +160,7 @@ class NestedInputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
             },
         },
 
-        'edges': [
+        'links': [
             {
                 'source': 'input connector',
                 'destination': 'Inner',
@@ -209,7 +209,7 @@ class NestedOutputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
                                 ]
                             },
                         },
-                        'edges': [
+                        'links': [
                             {
                                 'source': 'input connector',
                                 'destination': 'A',
@@ -227,7 +227,7 @@ class NestedOutputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
             },
         },
 
-        'edges': [
+        'links': [
             {
                 'source': 'input connector',
                 'destination': 'Inner',

--- a/tests/api/v1/test_post_workflow_failure.py
+++ b/tests/api/v1/test_post_workflow_failure.py
@@ -28,7 +28,7 @@ class InputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
                 'methods': [
                     {
                         'name': 'execute',
-                        'service': 'ShellCommand',
+                        'service': 'shell_command',
                         'parameters': {
                             'commandLine': ['cat']
                         }
@@ -39,7 +39,7 @@ class InputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
                 'methods': [
                     {
                         'name': 'execute',
-                        'service': 'ShellCommand',
+                        'service': 'shell_command',
                         'parameters': {
                             'commandLine': ['cat']
                         }
@@ -74,7 +74,7 @@ class OutputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
                 'methods': [
                     {
                         'name': 'execute',
-                        'service': 'ShellCommand',
+                        'service': 'shell_command',
                         'parameters': {
                             'commandLine': ['cat']
                         }
@@ -85,7 +85,7 @@ class OutputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
                 'methods': [
                     {
                         'name': 'execute',
-                        'service': 'ShellCommand',
+                        'service': 'shell_command',
                         'parameters': {
                             'commandLine': ['cat']
                         }
@@ -123,7 +123,7 @@ class NestedInputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
                                 'methods': [
                                     {
                                         'name': 'execute',
-                                        'service': 'ShellCommand',
+                                        'service': 'shell_command',
                                         'parameters': {
                                             'commandLine': ['cat']
                                         }
@@ -134,7 +134,7 @@ class NestedInputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
                                 'methods': [
                                     {
                                         'name': 'execute',
-                                        'service': 'ShellCommand',
+                                        'service': 'shell_command',
                                         'parameters': {
                                             'commandLine': ['cat']
                                         }
@@ -190,7 +190,7 @@ class NestedOutputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
                                 'methods': [
                                     {
                                         'name': 'execute',
-                                        'service': 'ShellCommand',
+                                        'service': 'shell_command',
                                         'parameters': {
                                             'commandLine': ['cat']
                                         }
@@ -201,7 +201,7 @@ class NestedOutputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
                                 'methods': [
                                     {
                                         'name': 'execute',
-                                        'service': 'ShellCommand',
+                                        'service': 'shell_command',
                                         'parameters': {
                                             'commandLine': ['cat']
                                         }

--- a/tests/api/v1/test_roundtrip_success.py
+++ b/tests/api/v1/test_roundtrip_success.py
@@ -65,32 +65,36 @@ class NestedWorkflow(RoundTripSuccess, BaseAPITest):
         'tasks': {
             'Inner': {
                 'methods': [{
-                    'tasks': {
-                        'A': {
-                            'methods': [
-                                {
-                                    'name': 'execute',
-                                    'service': 'shell_command',
-                                    'parameters': {
-                                        'commandLine': ['cat']
+                    'name': 'some_workflow',
+                    'parameters': {
+                        'tasks': {
+                            'A': {
+                                'methods': [
+                                    {
+                                        'name': 'execute',
+                                        'service': 'shell_command',
+                                        'parameters': {
+                                            'commandLine': ['cat']
+                                        }
                                     }
-                                }
-                            ]
+                                ]
+                            },
                         },
+                        'links': [
+                            {
+                                'source': 'input connector',
+                                'destination': 'A',
+                                'sourceProperty': 'inner_input',
+                                'destinationProperty': 'param',
+                            }, {
+                                'source': 'A',
+                                'destination': 'output connector',
+                                'sourceProperty': 'result',
+                                'destinationProperty': 'inner_output',
+                            },
+                        ],
                     },
-                    'links': [
-                        {
-                            'source': 'input connector',
-                            'destination': 'A',
-                            'sourceProperty': 'inner_input',
-                            'destinationProperty': 'param',
-                        }, {
-                            'source': 'A',
-                            'destination': 'output connector',
-                            'sourceProperty': 'result',
-                            'destinationProperty': 'inner_output',
-                        },
-                    ],
+                    'service': 'workflow',
                 }]
             },
         },
@@ -153,32 +157,36 @@ class NestedParallelByTaskWorkflow(RoundTripSuccess, BaseAPITest):
         'tasks': {
             'Inner': {
                 'methods': [{
-                    'tasks': {
-                        'A': {
-                            'methods': [
-                                {
-                                    'name': 'execute',
-                                    'service': 'shell_command',
-                                    'parameters': {
-                                        'commandLine': ['cat']
+                    'name': 'some_workflow',
+                    'parameters': {
+                        'tasks': {
+                            'A': {
+                                'methods': [
+                                    {
+                                        'name': 'execute',
+                                        'service': 'shell_command',
+                                        'parameters': {
+                                            'commandLine': ['cat']
+                                        }
                                     }
-                                }
-                            ]
+                                ]
+                            },
                         },
+                        'links': [
+                            {
+                                'source': 'input connector',
+                                'destination': 'A',
+                                'sourceProperty': 'inner_input',
+                                'destinationProperty': 'param',
+                            }, {
+                                'source': 'A',
+                                'destination': 'output connector',
+                                'sourceProperty': 'result',
+                                'destinationProperty': 'inner_output',
+                            },
+                        ],
                     },
-                    'links': [
-                        {
-                            'source': 'input connector',
-                            'destination': 'A',
-                            'sourceProperty': 'inner_input',
-                            'destinationProperty': 'param',
-                        }, {
-                            'source': 'A',
-                            'destination': 'output connector',
-                            'sourceProperty': 'result',
-                            'destinationProperty': 'inner_output',
-                        },
-                    ],
+                    'service': 'workflow',
                 }],
             },
         },

--- a/tests/api/v1/test_roundtrip_success.py
+++ b/tests/api/v1/test_roundtrip_success.py
@@ -33,7 +33,7 @@ class SingleNodeWorkflow(RoundTripSuccess, BaseAPITest):
                 'methods': [
                     {
                         'name': 'execute',
-                        'service': 'shell_command',
+                        'service': 'shell-command',
                         'parameters': {
                             'commandLine': ['cat']
                         }
@@ -72,7 +72,7 @@ class NestedWorkflow(RoundTripSuccess, BaseAPITest):
                                 'methods': [
                                     {
                                         'name': 'execute',
-                                        'service': 'shell_command',
+                                        'service': 'shell-command',
                                         'parameters': {
                                             'commandLine': ['cat']
                                         }
@@ -125,7 +125,7 @@ class ParallelByTaskWorkflow(RoundTripSuccess, BaseAPITest):
                 'methods': [
                     {
                         'name': 'execute',
-                        'service': 'shell_command',
+                        'service': 'shell-command',
                         'parameters': {
                             'commandLine': ['cat']
                         }
@@ -164,7 +164,7 @@ class NestedParallelByTaskWorkflow(RoundTripSuccess, BaseAPITest):
                                 'methods': [
                                     {
                                         'name': 'execute',
-                                        'service': 'shell_command',
+                                        'service': 'shell-command',
                                         'parameters': {
                                             'commandLine': ['cat']
                                         }

--- a/tests/api/v1/test_roundtrip_success.py
+++ b/tests/api/v1/test_roundtrip_success.py
@@ -33,7 +33,7 @@ class SingleNodeWorkflow(RoundTripSuccess, BaseAPITest):
                 'methods': [
                     {
                         'name': 'execute',
-                        'service': 'ShellCommand',
+                        'service': 'shell_command',
                         'parameters': {
                             'commandLine': ['cat']
                         }
@@ -70,7 +70,7 @@ class NestedWorkflow(RoundTripSuccess, BaseAPITest):
                             'methods': [
                                 {
                                     'name': 'execute',
-                                    'service': 'ShellCommand',
+                                    'service': 'shell_command',
                                     'parameters': {
                                         'commandLine': ['cat']
                                     }
@@ -121,7 +121,7 @@ class ParallelByTaskWorkflow(RoundTripSuccess, BaseAPITest):
                 'methods': [
                     {
                         'name': 'execute',
-                        'service': 'ShellCommand',
+                        'service': 'shell_command',
                         'parameters': {
                             'commandLine': ['cat']
                         }
@@ -158,7 +158,7 @@ class NestedParallelByTaskWorkflow(RoundTripSuccess, BaseAPITest):
                             'methods': [
                                 {
                                     'name': 'execute',
-                                    'service': 'ShellCommand',
+                                    'service': 'shell_command',
                                     'parameters': {
                                         'commandLine': ['cat']
                                     }

--- a/tests/api/v1/test_roundtrip_success.py
+++ b/tests/api/v1/test_roundtrip_success.py
@@ -21,7 +21,7 @@ class RoundTripSuccess(object):
 
     def test_get_should_return_post_data(self):
         get_response = self.get(self.response.headers.get('Location'))
-        key_names = ['tasks', 'edges', 'inputs']
+        key_names = ['tasks', 'links', 'inputs']
         for key in key_names:
             self.assertItemsEqual(self.post_data[key], get_response.DATA[key])
 
@@ -41,7 +41,7 @@ class SingleNodeWorkflow(RoundTripSuccess, BaseAPITest):
                 ]
             },
         },
-        'edges': [
+        'links': [
             {
                 'source': 'input connector',
                 'destination': 'A',
@@ -78,7 +78,7 @@ class NestedWorkflow(RoundTripSuccess, BaseAPITest):
                             ]
                         },
                     },
-                    'edges': [
+                    'links': [
                         {
                             'source': 'input connector',
                             'destination': 'A',
@@ -95,7 +95,7 @@ class NestedWorkflow(RoundTripSuccess, BaseAPITest):
             },
         },
 
-        'edges': [
+        'links': [
             {
                 'source': 'input connector',
                 'destination': 'Inner',
@@ -129,7 +129,7 @@ class ParallelByTaskWorkflow(RoundTripSuccess, BaseAPITest):
                 ]
             },
         },
-        'edges': [
+        'links': [
             {
                 'source': 'input connector',
                 'destination': 'A',
@@ -166,7 +166,7 @@ class NestedParallelByTaskWorkflow(RoundTripSuccess, BaseAPITest):
                             ]
                         },
                     },
-                    'edges': [
+                    'links': [
                         {
                             'source': 'input connector',
                             'destination': 'A',
@@ -183,7 +183,7 @@ class NestedParallelByTaskWorkflow(RoundTripSuccess, BaseAPITest):
             },
         },
 
-        'edges': [
+        'links': [
             {
                 'source': 'input connector',
                 'destination': 'Inner',


### PR DESCRIPTION
Service names are: 'workflow' and 'shell-command' (lower-case with hypens).
Edges are now Links.
All methods are declared with the same top level keys: 'name', 'parameters', 'service'.
JSON schema is very explicit about what services are supported.