### PR TITLE
Remove hyphen from name of MethodList table

### DIFF
--- a/ptero_workflow/implementation/models/task/method_list.py
+++ b/ptero_workflow/implementation/models/task/method_list.py
@@ -9,7 +9,7 @@ __all__ = ['MethodList']
 
 
 class MethodList(Task):
-    __tablename__ = 'method-list'
+    __tablename__ = 'method_list'
 
     id = Column(Integer, ForeignKey('task.id'), primary_key=True)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ psycopg2 == 2.5.4
 redis == 2.10.3
 requests == 2.4.3
 sqlalchemy == 0.9.8
--e git+https://github.com/genome/ptero-common.git@v0.2.0#egg=ptero_common
+-e git+https://github.com/genome/ptero-common.git@v0.2.1#egg=ptero_common


### PR DESCRIPTION
This makes cleanup with the janitor easier, because we don't have to
worry about quoting table names.