### PR TITLE
Do not use bash to background devserver

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -92,7 +92,7 @@ commands =
     rm -rf {toxinidir}/var
     coverage combine
     coverage erase
-    bash -c '{toxinidir}/devserver --num-workers 1 --logdir {toxinidir}/var/log --pidfile {toxinidir}/var/run/devserver.pid &'
+    {toxinidir}/devserver --num-workers 1 --logdir {toxinidir}/var/log --pidfile {toxinidir}/var/run/devserver.pid
     sleep {env:TRAVIS_WAIT_TIME:0}
     {toxinidir}/tests/scripts/run_tests
     bash -c 'PID=$(cat {toxinidir}/var/run/devserver.pid); kill $PID; while ps -p $PID >/dev/null; do sleep 1; done'


### PR DESCRIPTION
The ptero-common devserver detaches itself when invoked with --pidfile,
so it is no longer necessary to use the bash -c 'devserver &' to
background the devserver