### PR TITLE
Canceling and tests

### DIFF
--- a/ptero_workflow/api/v1/views.py
+++ b/ptero_workflow/api/v1/views.py
@@ -38,6 +38,20 @@ class WorkflowDetailView(Resource):
         workflow_as_dict = g.backend.get_workflow(workflow_id)
         return _prepare_workflow_data(workflow_id, workflow_as_dict), 200
 
+    @logged_response(logger=LOG)
+    def patch(self, workflow_id):
+        update_data = request.get_json()
+        forbidden_fields = set(update_data.keys()) - set(['is_canceled'])
+        if forbidden_fields:
+            msg = 'Cannot patch workflow fields: %s' % str(forbidden_fields)
+            return msg, 409
+        elif ('is_canceled' in update_data and update_data['is_canceled']):
+            g.backend.cancel_workflow(workflow_id)
+
+            workflow_as_dict = g.backend.get_workflow(workflow_id)
+            return _prepare_workflow_data(workflow_id, workflow_as_dict), 200
+
+
 class ExecutionDetailView(Resource):
     @logged_response(logger=LOG)
     def get(self, execution_id):

--- a/ptero_workflow/implementation/backend.py
+++ b/ptero_workflow/implementation/backend.py
@@ -69,6 +69,11 @@ class Backend(object):
     def get_workflow(self, workflow_id):
         return self.session.query(models.Workflow).get(workflow_id).as_dict
 
+    def cancel_workflow(self, workflow_id):
+        workflow = self.session.query(models.Workflow).get(workflow_id)
+        workflow.cancel()
+        self.session.commit()
+
     def get_workflow_status(self, workflow_id):
         return self.session.query(models.Workflow).get(workflow_id).status
 

--- a/ptero_workflow/implementation/models/methods/dag.py
+++ b/ptero_workflow/implementation/models/methods/dag.py
@@ -24,6 +24,12 @@ class DAGMethod(Method):
         'polymorphic_identity': 'DAG',
     }
 
+    def all_tasks_iterator(self):
+        for child in self.child_list:
+            yield child
+            for task in child.all_tasks_iterator():
+                yield task
+
     def attach_transitions(self, transitions, start_place):
         for child in self.child_list:
             child_start_place = self._child_start_place(child.name)

--- a/ptero_workflow/implementation/models/methods/method_base.py
+++ b/ptero_workflow/implementation/models/methods/method_base.py
@@ -32,6 +32,9 @@ class Method(Base):
 
     VALID_CALLBACK_TYPES = set()
 
+    def all_tasks_iterator(self):
+        return []
+
     def handle_callback(self, callback_type, body_data, query_string_data):
         if callback_type in self.VALID_CALLBACK_TYPES:
             return getattr(self, callback_type)(body_data, query_string_data)

--- a/ptero_workflow/implementation/models/methods/shell_command.py
+++ b/ptero_workflow/implementation/models/methods/shell_command.py
@@ -85,9 +85,12 @@ class ShellCommand(Method):
         s.add(execution)
         s.commit()
 
-        job_id = self._submit_to_shell_command(colors, begins, execution.id)
+        if (self.task.is_canceled):
+            execution.append_status('canceled')
+        else:
+            job_id = self._submit_to_shell_command(colors, begins, execution.id)
+            execution.data['job_id'] = job_id
 
-        execution.data['job_id'] = job_id
         s.commit()
 
     def begun(self, body_data, query_string_data):

--- a/ptero_workflow/implementation/models/task/method_list.py
+++ b/ptero_workflow/implementation/models/task/method_list.py
@@ -23,6 +23,11 @@ class MethodList(Task):
         'polymorphic_identity': 'method-list',
     }
 
+    def all_tasks_iterator(self):
+        for method in self.method_list:
+            for task in method.all_tasks_iterator():
+                yield task
+
     def attach_subclass_transitions(self, transitions, start_place):
         last_failure_place = start_place
         success_places = []

--- a/ptero_workflow/implementation/models/task/task_base.py
+++ b/ptero_workflow/implementation/models/task/task_base.py
@@ -42,6 +42,9 @@ class Task(Base):
         'polymorphic_on': 'type',
     }
 
+    def all_tasks_iterator(self):
+        return []
+
     @property
     def as_dict(self):
         result = {

--- a/ptero_workflow/implementation/models/task/task_base.py
+++ b/ptero_workflow/implementation/models/task/task_base.py
@@ -2,7 +2,7 @@ from ..base import Base
 from .. import result
 from .. import input_source
 from sqlalchemy import Column, UniqueConstraint
-from sqlalchemy import ForeignKey, Integer, Text
+from sqlalchemy import ForeignKey, Integer, Text, Boolean
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.session import object_session
@@ -36,11 +36,24 @@ class Task(Base):
     name      = Column(Text, nullable=False)
     type      = Column(Text, nullable=False)
     status = Column(Text)
+    is_canceled = Column(Boolean, default=False)
     parallel_by = Column(Text, nullable=True)
 
     __mapper_args__ = {
         'polymorphic_on': 'type',
     }
+
+    def cancel(self):
+        if self.parent is not None:
+            parent_info = " in DAG ID:%s with name (%s)" %\
+                    (self.parent.id, self.parent.name)
+        else:
+            parent_info = ''
+        LOG.info(
+            "Canceling task ID:%s with name (%s)%s",
+            self.id, self.name, parent_info)
+        self.is_canceled = True
+        self.status = 'canceled'
 
     def all_tasks_iterator(self):
         return []

--- a/ptero_workflow/implementation/models/workflow.py
+++ b/ptero_workflow/implementation/models/workflow.py
@@ -56,6 +56,11 @@ class Workflow(Base):
     def status(self):
         return self.root_task.status
 
+    def all_tasks_iterator(self):
+        yield self.root_task
+        for task in self.root_task.all_tasks_iterator():
+            yield task
+
     @property
     def as_dict(self):
         tasks = {name: task.as_dict for name,task in self.tasks.iteritems()

--- a/ptero_workflow/implementation/models/workflow.py
+++ b/ptero_workflow/implementation/models/workflow.py
@@ -62,6 +62,17 @@ class Workflow(Base):
             yield task
 
     @property
+    def is_canceled(self):
+        return self.root_task.is_canceled
+
+    def cancel(self):
+        if self.is_canceled:
+            return
+        else:
+            for task in self.all_tasks_iterator():
+                task.cancel()
+
+    @property
     def as_dict(self):
         tasks = {name: task.as_dict for name,task in self.tasks.iteritems()
                 if name not in ['input connector', 'output connector']}

--- a/tests/api/v1/test_cancel_workflow.py
+++ b/tests/api/v1/test_cancel_workflow.py
@@ -1,0 +1,54 @@
+from ..base import BaseAPITest
+
+
+class TestCancelWorkflow(BaseAPITest):
+    @property
+    def post_data(self):
+        return {
+                'tasks': {
+                    'A': {
+                        'methods': [
+                            {
+                                'name': 'execute',
+                                'service': 'shell-command',
+                                'parameters': {
+                                    'commandLine': ['cat'],
+                                    'user': 'testuser',
+                                    'workingDirectory': '/test/working/directory'
+                                    }
+                                }
+                            ]
+                        },
+                    },
+                'links': [
+                    {
+                        'source': 'input connector',
+                        'destination': 'A',
+                        'sourceProperty': 'in_a',
+                        'destinationProperty': 'param',
+                        },
+                    {
+                        'source': 'A',
+                        'destination': 'output connector',
+                        'sourceProperty': 'result',
+                        'destinationProperty': 'out_a',
+                        },
+                    ],
+                'inputs': {
+                    'in_a': 'kittens',
+                    },
+                }
+
+
+    def test_can_cancel(self):
+        post_response = self.post(self.post_url, self.post_data)
+
+        self.assertEqual(201, post_response.status_code)
+        self.assertTrue(post_response.DATA.get('status') is None)
+
+        workflow_url = post_response.headers['Location']
+        self.patch(workflow_url, data={'is_canceled':True})
+
+        get_response = self.get(workflow_url)
+        self.assertEqual(200, get_response.status_code)
+        self.assertEqual(get_response.DATA['status'], 'canceled')


### PR DESCRIPTION
We're going to have to consider the status situation further.  With this commit, no matter the status of the `Task`, it is set to 'canceled'.  We probably want to define a set of valid status transitions as well as add some status history tracking to all entities with status (currently it is only tracked on the `Execution` objects).

Looking ahead to reporting, it probably makes sense to have an `Execution` that is associated with each `DAGMethod` as well as one that is associated with each `Task`.  `Execution` objects are only made for the `ShellCommand` methods currently.  If we started making them for all tasks and methods it will likely make reporting a lot simpler for parallel-by and nested parallel-by.  Then these status fields would just live on the executions and not on the tasks.