### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-celery == 3.1.17
+celery == 3.1.18
 flask == 0.10.1
 flask-restful == 0.2.12
 gunicorn == 19.1.1
 jsonschema == 2.4.0
 librabbitmq == 1.6.1
-psycopg2 == 2.5.4
+psycopg2 == 2.6
 redis == 2.10.3
-sqlalchemy == 0.9.8
+sqlalchemy == 1.0.1
 -e git+https://github.com/genome/ptero-common.git@master#egg=ptero_common

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
-honcho == 0.5.0
+honcho == 0.6.6
 nose >= 1.3.0
 nose-cov
 psutil
 pyyaml
-requests == 2.4.3
+requests == 2.6.2


### PR DESCRIPTION
Didn't update `Flask-RESTful` because it broke tests.
Didn't update `gunicorn` because it would remain untested until deploy.