### PR TITLE
Attach transitions to expire completed nets in petri service

### DIFF
--- a/ptero_workflow/implementation/models/workflow.py
+++ b/ptero_workflow/implementation/models/workflow.py
@@ -127,12 +127,12 @@ class Workflow(Base):
         success_place, failure_place = self.root_task.attach_transitions(
                 transitions, self.start_place_name)
 
-        success_ttl = os.environ.get('PTERO_WORKFLOW_SUCCESS_EXPIRE_SECONDS')
+        success_ttl = os.environ.get('PTERO_WORKFLOW_SUCCEEDED_EXPIRE_SECONDS')
         if success_ttl is not None:
             self.attach_expire_transition(transitions, success_place,
                     int(success_ttl))
 
-        failure_ttl = os.environ.get('PTERO_WORKFLOW_FAILURE_EXPIRE_SECONDS')
+        failure_ttl = os.environ.get('PTERO_WORKFLOW_FAILED_EXPIRE_SECONDS')
         if failure_ttl is not None:
             self.attach_expire_transition(transitions, failure_place,
                     int(failure_ttl))

--- a/tests/test_workflow_petri_translation.py
+++ b/tests/test_workflow_petri_translation.py
@@ -1,0 +1,93 @@
+import os
+import unittest
+from ptero_workflow.api.v1 import validators
+from ptero_workflow.implementation.factory import Factory
+from ptero_workflow.implementation import translator
+
+class TestWorkflowPetriTranslation(unittest.TestCase):
+
+    @property
+    def workflow_data(self):
+        pass
+
+    @property
+    def petri_data(self):
+        factory = Factory(os.environ.get('PTERO_WORKFLOW_DB_STRING', 'sqlite://'))
+        self.backend = factory.create_backend()
+        workflow = self.backend._save_workflow(self.workflow_data)
+        return translator.build_petri_net(workflow)
+
+    @property
+    def expire_actions(self):
+        return [ i for i in self.petri_data['transitions']
+            if i.get('action') and i['action']['type'] == 'expire' ]
+
+    @property
+    def workflow_data(self):
+        return {
+            'tasks': {
+                'A': {
+                    'methods': [
+                        {
+                            'name': 'execute',
+                            'service': 'shell-command',
+                            'parameters': {
+                                'commandLine': ['./echo_command'],
+                                'user': 'dummy-user',
+                                'workingDirectory': '/tmp',
+                                'environment': {}
+                            }
+                        }
+                    ]
+                }
+            },
+
+            'links': [
+                {
+                    'source': 'input connector',
+                    'destination': 'A',
+                    'sourceProperty': 'in_a',
+                    'destinationProperty': 'param'
+                },
+                {
+                    'source': 'A',
+                    'destination': 'output connector',
+                    'sourceProperty': 'param',
+                    'destinationProperty': 'out_a'
+                }
+            ],
+
+            'inputs': {
+                'in_a': 'kittens'
+            }
+        }
+
+    def set_expire(self, type, ttl):
+        os.environ['PTERO_WORKFLOW_%s_EXPIRE_SECONDS' % type] = str(ttl)
+
+    def unset_expire(self, type):
+        if os.environ.get('PTERO_WORKFLOW_%s_EXPIRE_SECONDS' % type):
+            del os.environ['PTERO_WORKFLOW_%s_EXPIRE_SECONDS' % type]
+
+    def test_has_no_expire_actions(self):
+        self.unset_expire('SUCCESS')
+        self.unset_expire('FAILURE')
+        self.assertTrue( len(self.expire_actions) == 0 )
+
+    def test_success_expire_actions(self):
+        self.set_expire('SUCCESS', 1)
+        self.unset_expire('FAILURE')
+        self.assertTrue( len(self.expire_actions) == 1 )
+
+    def test_failure_expire_actions(self):
+        self.set_expire('FAILURE', 1)
+        self.unset_expire('SUCCESS')
+        self.assertTrue( len(self.expire_actions) == 1 )
+
+    def test_success_and_failure_expire_actions(self):
+        self.set_expire('SUCCESS', 1)
+        self.set_expire('FAILURE', 1)
+        self.assertTrue( len(self.expire_actions) == 2 )
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_workflow_petri_translation.py
+++ b/tests/test_workflow_petri_translation.py
@@ -70,23 +70,23 @@ class TestWorkflowPetriTranslation(unittest.TestCase):
             del os.environ['PTERO_WORKFLOW_%s_EXPIRE_SECONDS' % type]
 
     def test_has_no_expire_actions(self):
-        self.unset_expire('SUCCESS')
-        self.unset_expire('FAILURE')
+        self.unset_expire('SUCCEEDED')
+        self.unset_expire('FAILED')
         self.assertTrue( len(self.expire_actions) == 0 )
 
     def test_success_expire_actions(self):
-        self.set_expire('SUCCESS', 1)
-        self.unset_expire('FAILURE')
+        self.set_expire('SUCCEEDED', 1)
+        self.unset_expire('FAILED')
         self.assertTrue( len(self.expire_actions) == 1 )
 
     def test_failure_expire_actions(self):
-        self.set_expire('FAILURE', 1)
-        self.unset_expire('SUCCESS')
+        self.set_expire('FAILED', 1)
+        self.unset_expire('SUCCEEDED')
         self.assertTrue( len(self.expire_actions) == 1 )
 
     def test_success_and_failure_expire_actions(self):
-        self.set_expire('SUCCESS', 1)
-        self.set_expire('FAILURE', 1)
+        self.set_expire('SUCCEEDED', 1)
+        self.set_expire('FAILED', 1)
         self.assertTrue( len(self.expire_actions) == 2 )
 
 if __name__ == '__main__':


### PR DESCRIPTION
When submitting a net to Petri, construct the net so that expire actions are tacked onto the end, so that Petri will expire the net automatically when the net is completed.

Instead of inspecting Petri's net storage redis for expired keys, this feature is tested by inspecting the net transitions that would be sent to Petri.  This required a new kind of test which is not a BaseAPITest.