### PR TITLE
Wait for devserver in dev and dev-noenv testenvs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -67,6 +67,9 @@ commands =
     find {toxinidir}/ptero_workflow -name '*.pyc' -delete
     rm -rf {toxinidir}/var
     devserver --procfile {toxinidir}/tests/scripts/Procfile {posargs}
+    wait_for_service PTERO_PETRI_HOST PTERO_PETRI_PORT
+    wait_for_service PTERO_SHELL_COMMAND_HOST PTERO_SHELL_COMMAND_PORT
+    wait_for_service PTERO_WORKFLOW_HOST PTERO_WORKFLOW_RABBITMQ_NODE_PORT
 
 [testenv:dev-noenv]
 passenv = *
@@ -80,6 +83,9 @@ commands =
     find {toxinidir}/ptero_workflow -name '*.pyc' -delete
     rm -rf {toxinidir}/var
     devserver --procfile {toxinidir}/tests/scripts/Procfile {posargs}
+    wait_for_service PTERO_PETRI_HOST PTERO_PETRI_PORT
+    wait_for_service PTERO_SHELL_COMMAND_HOST PTERO_SHELL_COMMAND_PORT
+    wait_for_service PTERO_WORKFLOW_HOST PTERO_WORKFLOW_RABBITMQ_NODE_PORT
 
 
 [testenv:tests-only]


### PR DESCRIPTION
If we merge this commit, we can remove the 30 second sleep from the
Jenkins integration tests.