### PR TITLE
Add workflow_id to LOG messages

### DIFF
--- a/ptero_workflow/api/v1/views.py
+++ b/ptero_workflow/api/v1/views.py
@@ -102,8 +102,10 @@ class ExecutionDetailView(Resource):
                     update_data=update_data)
             return execution_data, 200
         except exceptions.ImmutableUpdateError as e:
-            LOG.exception('ImmutableUpdateError occured while updating '
-                'execution (%d) with update_data=%s', execution_id, update_data)
+            LOG.exception('%s - ImmutableUpdateError occured while updating '
+                'execution (%s) with update_data=%s', 
+                g.backend.get_workflow_id_from_execution_id(execution_id),
+                execution_id, update_data)
             return e.message, 409
 
 

--- a/ptero_workflow/implementation/backend.py
+++ b/ptero_workflow/implementation/backend.py
@@ -147,6 +147,10 @@ class Backend(object):
 
         return workflow
 
+    def get_workflow_id_from_execution_id(self, execution_id):
+        execution = self.session.query(Execution).get(execution_id)
+        return execution.workflow_id
+
     def _get_workflow(self, workflow_id):
         workflow = self.session.query(models.Workflow).get(workflow_id)
         if workflow is not None:

--- a/ptero_workflow/implementation/models/execution/execution_base.py
+++ b/ptero_workflow/implementation/models/execution/execution_base.py
@@ -90,8 +90,9 @@ class Execution(Base):
                     (status, str(statuses.VALID_STATUSES)))
         else:
             if not statuses.is_valid_transition(self.status, status):
-                LOG.debug("Refusing to change status from (%s) to (%s), valid status transitions are: %s",
-                    self.status, status, str(statuses.VALID_STATUS_TRANSITIONS[status]))
+                LOG.debug("%s - Refusing to change status from (%s) to (%s), valid status transitions are: %s",
+                    self.workflow_id, self.status, status,
+                    str(statuses.VALID_STATUS_TRANSITIONS[status]))
             else:
                 self.send_webhooks(status)
                 self._status = status

--- a/ptero_workflow/implementation/models/input_source.py
+++ b/ptero_workflow/implementation/models/input_source.py
@@ -50,8 +50,9 @@ class InputSource(Base):
         return indexes
 
     def get_data(self, colors, begins):
-        LOG.debug('get_data %s[%s] -> %s[%s] with parallel_depths=%s, '
+        LOG.debug('%s - get_data %s[%s] -> %s[%s] with parallel_depths=%s, '
                 'colors=%s, begins=%s',
+                self.workflow_id,
                 self.destination_task.name, self.destination_property,
                 self.source_task.name, self.source_property,
                 self.parallel_depths, colors, begins)
@@ -62,9 +63,9 @@ class InputSource(Base):
                 ).filter(result.Result.color.in_(colors)).one()
 
         indexes = self.parallel_indexes(colors, begins)
-        LOG.debug('%s[%s]  parallel_depths=%s, colors=%s, begins=%s '
+        LOG.debug('%s - %s[%s]  parallel_depths=%s, colors=%s, begins=%s '
                 '-> indexes=%s',
-                self.source_task.name, self.source_property,
+                self.workflow_id, self.source_task.name, self.source_property,
                 self.parallel_depths, colors, begins, indexes)
         return r.get_data(indexes)
 

--- a/ptero_workflow/implementation/models/input_source.py
+++ b/ptero_workflow/implementation/models/input_source.py
@@ -36,6 +36,11 @@ class InputSource(Base):
     destination_task = relationship('Task', backref='input_sources',
             foreign_keys=[destination_id])
 
+    workflow_id = Column(Integer, ForeignKey('workflow.id'),
+        nullable=False, index=True)
+    workflow = relationship('Workflow', foreign_keys=[workflow_id],
+            backref='all_input_sources')
+
     def parallel_indexes(self, colors, begins):
         indexes = []
         for depth in self.parallel_depths:

--- a/ptero_workflow/implementation/models/task/input_connector.py
+++ b/ptero_workflow/implementation/models/task/input_connector.py
@@ -35,7 +35,8 @@ class InputConnector(Task):
             self._set_dag_status_running(color)
             response_url = body_data['response_links']['success']
         except:
-            LOG.exception("Unexpected exception setting dag status to running")
+            LOG.exception("%s Unexpected exception setting dag status to running",
+                    self.workflow_id)
             response_url = body_data['response_links']['failure']
         self.http.delay('PUT', response_url)
 

--- a/ptero_workflow/implementation/models/task/task_base.py
+++ b/ptero_workflow/implementation/models/task/task_base.py
@@ -501,6 +501,7 @@ class Task(Base, PetriMixin):
                     destination_task=self,
                     destination_property=e.destination_property,
                     parallel_depths=source_parallel_depths,
+                    workflow=self.workflow,
             )
             session.add(in_source)
 

--- a/ptero_workflow/implementation/models/task/task_base.py
+++ b/ptero_workflow/implementation/models/task/task_base.py
@@ -83,8 +83,8 @@ class Task(Base, PetriMixin):
         else:
             parent_info = ''
         LOG.info(
-            "Canceling task ID:%s with name (%s)%s",
-            self.id, self.name, parent_info)
+                "%s - Canceling task ID:%s with name (%s)%s",
+            self.workflow_id, self.id, self.name, parent_info)
         self.is_canceled = True
         for execution in self.executions.values():
             execution.status = statuses.canceled
@@ -309,7 +309,7 @@ class Task(Base, PetriMixin):
             size = source.get_size(colors, begins)
         except Exception as e:
             s.rollback()
-            LOG.exception('Failed to get split size')
+            LOG.exception('%s - Failed to get split size', self.workflow_id)
             self.http.delay('PUT', response_links['failure'])
             execution = s.query(TaskExecution).filter(
                     TaskExecution.task==self,
@@ -319,8 +319,8 @@ class Task(Base, PetriMixin):
             s.commit()
             return
 
-        LOG.debug('Split size for %s[%s] colors=%s is %s',
-                self.name, self.parallel_by, colors, size)
+        LOG.debug('%s - Split size for %s[%s] colors=%s is %s',
+                self.workflow_id, self.name, self.parallel_by, colors, size)
         self.http.delay('PUT', response_links['send_data'],
                 color_group_size=size)
 
@@ -410,8 +410,8 @@ class Task(Base, PetriMixin):
             inputs[source.destination_property] = source.get_data(
                     colors, begins)
 
-        LOG.debug('Got inputs for %s, colors=%s: %s', self.name,
-                colors, inputs)
+        LOG.debug('%s - Got inputs for %s, colors=%s: %s', self.workflow_id, 
+                self.name, colors, inputs)
 
         return inputs
 
@@ -485,13 +485,14 @@ class Task(Base, PetriMixin):
         return self, name, parallel_depths
 
     def create_input_sources(self, session, parallel_depths):
-        LOG.debug('Creating input sources for %s', self.name)
+        LOG.debug('%s - Creating input sources for %s', self.workflow_id, 
+                self.name)
         for e in self.input_links:
             source_task, source_property, source_parallel_depths = \
                     self.resolve_input_source(session, e.destination_property,
                             parallel_depths)
-            LOG.debug('Found input source %s[%s] = %s[%s]: parallel_depths=%s',
-                    self.name, e.destination_property,
+            LOG.debug('%s - Found input source %s[%s] = %s[%s]: parallel_depths=%s',
+                    self.workflow_id, self.name, e.destination_property,
                     source_task.name, source_property,
                     source_parallel_depths)
 

--- a/ptero_workflow/implementation/tasks.py
+++ b/ptero_workflow/implementation/tasks.py
@@ -89,7 +89,6 @@ def get_deterministic_topological_ordering(nodes, links, start_node):
     Topological sort that is deterministic because it sorts (alphabetically)
     candidates to check
     """
-    LOG.warn("nodes: %s\nlinks: %s", nodes, links)
     graph = DiGraph()
     graph.add_nodes_from(nodes)
     for link in links:


### PR DESCRIPTION
The HTTP request/response log messages do not generally have any mechanism to determine the workflow_id, so they were left out of this change.