### PR TITLE
Add workflow_id to flask request

### DIFF
--- a/ptero_workflow/implementation/backend.py
+++ b/ptero_workflow/implementation/backend.py
@@ -149,15 +149,27 @@ class Backend(object):
 
     def get_workflow_id_from_execution_id(self, execution_id):
         execution = self.session.query(Execution).get(execution_id)
-        return execution.workflow_id
+        if execution is not None:
+            return execution.workflow_id
+        else:
+            raise exceptions.NoSuchEntityError(
+                    "Execution with id %s was not found." % execution_id)
 
     def get_workflow_id_from_task_id(self, task_id):
         task = self.session.query(models.Task).get(task_id)
-        return task.workflow_id
+        if task is not None:
+            return task.workflow_id
+        else:
+            raise exceptions.NoSuchEntityError(
+                    "Task with id %s was not found." % task_id)
 
     def get_workflow_id_from_method_id(self, method_id):
         method = self.session.query(models.Method).get(method_id)
-        return method.workflow_id
+        if method is not None:
+            return method.workflow_id
+        else:
+            raise exceptions.NoSuchEntityError(
+                    "Method with id %s was not found." % method_id)
 
     def _get_workflow(self, workflow_id):
         workflow = self.session.query(models.Workflow).get(workflow_id)

--- a/ptero_workflow/implementation/backend.py
+++ b/ptero_workflow/implementation/backend.py
@@ -151,6 +151,14 @@ class Backend(object):
         execution = self.session.query(Execution).get(execution_id)
         return execution.workflow_id
 
+    def get_workflow_id_from_task_id(self, task_id):
+        task = self.session.query(models.Task).get(task_id)
+        return task.workflow_id
+
+    def get_workflow_id_from_method_id(self, method_id):
+        method = self.session.query(models.Method).get(method_id)
+        return method.workflow_id
+
     def _get_workflow(self, workflow_id):
         workflow = self.session.query(models.Workflow).get(workflow_id)
         if workflow is not None:


### PR DESCRIPTION
This allows the 'workflowId' field to be included in the log JSON.

The requests sent from the celery HTTP task do not have a flask request context.  In order to log the 'workflowId' there we will need another strategy.