### PR TITLE
Ensure outputs are set by ShellCommand methods

### DIFF
--- a/ptero_workflow/api/v1/views.py
+++ b/ptero_workflow/api/v1/views.py
@@ -107,11 +107,10 @@ class ExecutionDetailView(Resource):
             execution_data = g.backend.update_execution(execution_id,
                     update_data=update_data)
             return execution_data, 200
-        except exceptions.ImmutableUpdateError as e:
-            LOG.exception('%s - ImmutableUpdateError occured while updating '
-                'execution (%s) with update_data=%s', 
+        except exceptions.UpdateError as e:
+            LOG.exception('%s - Error occured while updating execution (%s): %s',
                 g.backend.get_workflow_id_from_execution_id(execution_id),
-                execution_id, update_data)
+                execution_id, e.message)
             return e.message, 409
 
 

--- a/ptero_workflow/implementation/backend.py
+++ b/ptero_workflow/implementation/backend.py
@@ -278,7 +278,13 @@ class Backend(object):
 
     def update_execution(self, execution_id, update_data):
         execution = self._get_execution(execution_id)
-        execution.update(update_data)
+
+        try:
+            execution.update(update_data)
+        except exceptions.UpdateError:
+            self.session.rollback()
+            raise
+
         self.session.commit()
         return execution.as_dict(detailed=False)
 

--- a/ptero_workflow/implementation/backend.py
+++ b/ptero_workflow/implementation/backend.py
@@ -279,11 +279,7 @@ class Backend(object):
     def update_execution(self, execution_id, update_data):
         execution = self._get_execution(execution_id)
         execution.update(update_data)
-        try:
-            self.session.commit()
-        except IntegrityError:
-            self.session.rollback()
-            raise exceptions.OutputsAlreadySet
+        self.session.commit()
         return execution.as_dict(detailed=False)
 
     def handle_task_callback(self, task_id, callback_type, body_data,

--- a/ptero_workflow/implementation/exceptions.py
+++ b/ptero_workflow/implementation/exceptions.py
@@ -1,7 +1,10 @@
 class InvalidWorkflow(Exception):
     pass
 
-class ImmutableUpdateError(Exception):
+class UpdateError(Exception):
+    pass
+
+class ImmutableUpdateError(UpdateError):
     pass
 
 class OutputsAlreadySet(ImmutableUpdateError):

--- a/ptero_workflow/implementation/exceptions.py
+++ b/ptero_workflow/implementation/exceptions.py
@@ -10,8 +10,12 @@ class ImmutableUpdateError(UpdateError):
 class OutputsAlreadySet(ImmutableUpdateError):
     pass
 
+class MissingOutputError(UpdateError):
+    pass
+
 class InvalidStatusError(RuntimeError):
     pass
 
 class NoSuchEntityError(RuntimeError):
     pass
+

--- a/ptero_workflow/implementation/exceptions.py
+++ b/ptero_workflow/implementation/exceptions.py
@@ -19,3 +19,5 @@ class InvalidStatusError(RuntimeError):
 class NoSuchEntityError(RuntimeError):
     pass
 
+class MissingResultError(RuntimeError):
+    pass

--- a/ptero_workflow/implementation/models/execution/execution_base.py
+++ b/ptero_workflow/implementation/models/execution/execution_base.py
@@ -53,20 +53,6 @@ class Execution(Base):
         'outputs': 'update_outputs',
     }
 
-    @property
-    def name(self):
-        if self.method_id is not None:
-            return "%s.%s.%s" % (
-                    self.method.task.name,
-                    self.method.name,
-                    self.id,
-            )
-        else:
-            return "%s.%s" % (
-                    self.task.name,
-                    self.id,
-            )
-
     def __init__(self, *args, **kwargs):
         Base.__init__(self, *args, **kwargs)
         self._status = 'new'

--- a/ptero_workflow/implementation/models/execution/method_execution.py
+++ b/ptero_workflow/implementation/models/execution/method_execution.py
@@ -27,3 +27,15 @@ class MethodExecution(Execution):
 
     def get_outputs(self):
         return self.method.task.get_outputs(color=self.color)
+
+    @property
+    def outputs_are_set(self):
+        return self.method.task.outputs_for_color_are_set(self.color)
+
+    @property
+    def missing_outputs(self):
+        outputs = self.get_outputs()
+        if outputs is not None:
+            return self.method.task.output_properties - set(self.get_outputs())
+        else:
+            return self.method.task.output_properties

--- a/ptero_workflow/implementation/models/execution/method_execution.py
+++ b/ptero_workflow/implementation/models/execution/method_execution.py
@@ -10,6 +10,14 @@ class MethodExecution(Execution):
     }
 
     @property
+    def name(self):
+        return "%s.%s.%s" % (
+                self.method.task.name,
+                self.method.name,
+                self.id,
+        )
+
+    @property
     def parent(self):
         return self.method
 

--- a/ptero_workflow/implementation/models/execution/method_execution.py
+++ b/ptero_workflow/implementation/models/execution/method_execution.py
@@ -26,7 +26,4 @@ class MethodExecution(Execution):
                 begins=self.begins)
 
     def get_outputs(self):
-        s = object_session(self)
-        query_results = s.query(result.Result).filter_by(task=self.method.task,
-            color=self.color, parent_color=self.parent_color).all()
-        return {r.name: r.data for r in query_results}
+        return self.method.task.get_outputs(color=self.color)

--- a/ptero_workflow/implementation/models/execution/task_execution.py
+++ b/ptero_workflow/implementation/models/execution/task_execution.py
@@ -25,7 +25,4 @@ class TaskExecution(Execution):
                 begins=self.begins)
 
     def get_outputs(self):
-        s = object_session(self)
-        query_results = s.query(result.Result).filter_by(task=self.task,
-            color=self.color, parent_color=self.parent_color).all()
-        return {r.name: r.data for r in query_results}
+        return self.task.get_outputs(color=self.color)

--- a/ptero_workflow/implementation/models/execution/task_execution.py
+++ b/ptero_workflow/implementation/models/execution/task_execution.py
@@ -10,6 +10,13 @@ class TaskExecution(Execution):
     }
 
     @property
+    def name(self):
+        return "%s.%s" % (
+                self.task.name,
+                self.id,
+        )
+
+    @property
     def parent(self):
         return self.task
 

--- a/ptero_workflow/implementation/models/methods/shell_command.py
+++ b/ptero_workflow/implementation/models/methods/shell_command.py
@@ -102,44 +102,45 @@ class ShellCommand(Method):
         execution.status = running
         s.commit()
 
-    def succeeded(self, body_data, query_string_data):
-        execution_id = query_string_data['execution_id']
-
+    def _get_execution(self, execution_id):
         s = object_session(self)
-        execution = s.query(MethodExecution).filter_by(id=execution_id,
+        return s.query(MethodExecution).filter_by(id=execution_id,
                 method_id=self.id).one()
+
+    def succeeded(self, body_data, query_string_data):
+        execution = self._get_execution(query_string_data['execution_id'])
 
         execution.status = succeeded
         execution.data.update(body_data)
+
+        s = object_session(self)
         s.commit()
+
         response_url = execution.data['petri_response_links_for_shell_command']['success']
 
         self.http.delay('PUT', response_url)
 
     def failed(self, body_data, query_string_data):
-        execution_id = query_string_data['execution_id']
-
-        s = object_session(self)
-        execution = s.query(MethodExecution).filter_by(id=execution_id,
-                method_id=self.id).one()
+        execution = self._get_execution(query_string_data['execution_id'])
 
         execution.status = failed
         execution.data.update(body_data)
+
+        s = object_session(self)
         s.commit()
         response_url = execution.data['petri_response_links_for_shell_command']['failure']
 
         self.http.delay('PUT', response_url)
 
     def errored(self, body_data, query_string_data):
-        execution_id = query_string_data['execution_id']
-
-        s = object_session(self)
-        execution = s.query(MethodExecution).filter_by(id=execution_id,
-                method_id=self.id).one()
+        execution = self._get_execution(query_string_data['execution_id'])
 
         execution.status = errored
         execution.data.update(body_data)
+
+        s = object_session(self)
         s.commit()
+
         response_url = execution.data['petri_response_links_for_shell_command']['failure']
         self.http.delay('PUT', response_url)
 

--- a/ptero_workflow/implementation/models/task/input_holder.py
+++ b/ptero_workflow/implementation/models/task/input_holder.py
@@ -1,4 +1,5 @@
 from .task_base import Task
+from .. import result
 from sqlalchemy import Column, ForeignKey, Integer
 
 
@@ -16,3 +17,8 @@ class InputHolder(Task):
 
     def __init__(self, *args, **kwargs):
         return super(InputHolder, self).__init__(*args, topological_index=-1, **kwargs)
+
+    def set_outputs(self, outputs, color, parent_color):
+        for name, value in outputs.iteritems():
+            result.Result(task=self, name=name, data=value,
+                    color=color, parent_color=parent_color)

--- a/ptero_workflow/implementation/models/task/task_base.py
+++ b/ptero_workflow/implementation/models/task/task_base.py
@@ -527,6 +527,11 @@ class Task(Base, PetriMixin):
         if results:
             return {r.name: r.data for r in results}
 
+    def outputs_for_color_are_set(self, color):
+        s = object_session(self)
+        num_results = s.query(result.Result).filter_by(task=self, color=color).count()
+        return num_results > 0
+
 def _get_parent_color(colors):
     if len(colors) == 1:
         return None

--- a/ptero_workflow/implementation/models/task/task_base.py
+++ b/ptero_workflow/implementation/models/task/task_base.py
@@ -16,6 +16,7 @@ import logging
 import os
 import urllib
 from ptero_common import statuses
+from ptero_workflow.implementation import exceptions
 
 
 __all__ = ['Task']
@@ -399,10 +400,19 @@ class Task(Base, PetriMixin):
         else:
             return []
 
+    @property
+    def output_properties(self):
+        return set([l.source_property for l in self.output_links])
+
     def set_outputs(self, outputs, color, parent_color):
-        for name, value in outputs.iteritems():
-            result.Result(task=self, name=name, data=value,
-                    color=color, parent_color=parent_color)
+        for output_property in self.output_properties:
+            if output_property not in outputs.keys():
+                raise exceptions.MissingOutputError(
+                        "No value specified for output (%s), outputs specified were: %s" %
+                        (output_property, str(outputs.keys())))
+            else:
+                result.Result(task=self, name=output_property, data=outputs[output_property],
+                        color=color, parent_color=parent_color)
 
     def get_inputs(self, colors, begins):
         inputs = {}

--- a/tests/api/v1/generator/base_case.py
+++ b/tests/api/v1/generator/base_case.py
@@ -86,6 +86,10 @@ class TestCaseMixin(object):
             self._verify_result(outputs_report_url)
         else:
             LOG.info("Workflow failed... Checking expected details")
+
+            details_url = workflow_data['reports']['workflow-details']
+            self._regenerate_details_data(details_url)
+
             self.assertTrue(self._expected_details is not None)
 
         if self._expected_details is not None:
@@ -101,6 +105,12 @@ class TestCaseMixin(object):
         self._regenerate_executions_data(url)
         if self._expected_executions is not None:
             self._verify_workflow_executions(url)
+
+    def _regenerate_details_data(self, url):
+        if os.environ.get('PTERO_REGENERATE_TEST_DATA'):
+            actual_result = self._get_actual_result(url)
+            with open(self._expected_details_path, 'w') as ofile:
+                ofile.write(self._to_json(actual_result))
 
     def _regenerate_skeleton_data(self, url):
         if os.environ.get('PTERO_REGENERATE_TEST_DATA'):

--- a/tests/api/v1/system_tests/output_neglecting_command/README.txt
+++ b/tests/api/v1/system_tests/output_neglecting_command/README.txt
@@ -1,0 +1,4 @@
+This test runs a command that fails to set a required output.  The method
+should end up in the 'errored' state with a message in the execution data
+explaining the error.  This will cause the task to end up in the 'failed'
+state.  The workflow should end up 'failed' as well.

--- a/tests/api/v1/system_tests/output_neglecting_command/submit.json
+++ b/tests/api/v1/system_tests/output_neglecting_command/submit.json
@@ -1,0 +1,50 @@
+{
+    "tasks": {
+        "A": {
+            "methods": [
+                {
+                    "name": "execute",
+                    "service": "shell-command",
+                    "parameters": {
+                        "commandLine": ["./output_neglecting_command"],
+                        "user": "{{ user }}",
+                        "workingDirectory": "{{ workingDirectory }}",
+                        "environment": {{ environment }}
+                    }
+                }
+            ]
+        }
+    },
+
+    "links": [
+        {
+            "source": "input connector",
+            "destination": "A",
+            "sourceProperty": "in_a",
+            "destinationProperty": "param_a"
+        },
+        {
+            "source": "A",
+            "destination": "output connector",
+            "sourceProperty": "param_a",
+            "destinationProperty": "out_a"
+        },
+        {
+            "source": "input connector",
+            "destination": "A",
+            "sourceProperty": "in_b",
+            "destinationProperty": "param_b"
+        },
+        {
+            "source": "A",
+            "destination": "output connector",
+            "sourceProperty": "param_b",
+            "destinationProperty": "out_b"
+        }
+    ],
+
+    "inputs": {
+        "in_a": "kittens",
+        "in_b": "puppies"
+    }
+}

--- a/tests/api/v1/system_tests/output_neglecting_command/workflow_details.json
+++ b/tests/api/v1/system_tests/output_neglecting_command/workflow_details.json
@@ -1,0 +1,55 @@
+{
+    "inputs": {
+        "in_a": "kittens", 
+        "in_b": "puppies"
+    }, 
+    "links": [
+        {
+            "destination": "output connector", 
+            "destinationProperty": "out_a", 
+            "source": "A", 
+            "sourceProperty": "param_a"
+        }, 
+        {
+            "destination": "output connector", 
+            "destinationProperty": "out_b", 
+            "source": "A", 
+            "sourceProperty": "param_b"
+        }, 
+        {
+            "destination": "A", 
+            "destinationProperty": "param_a", 
+            "source": "input connector", 
+            "sourceProperty": "in_a"
+        }, 
+        {
+            "destination": "A", 
+            "destinationProperty": "param_b", 
+            "source": "input connector", 
+            "sourceProperty": "in_b"
+        }
+    ], 
+    "tasks": {
+        "A": {
+            "executions": {
+                "0": { "status": "failed" }
+            }, 
+            "methods": [
+                {
+                    "executions": {
+                        "0": { "status": "errored" }
+                    }, 
+                    "name": "execute", 
+                    "parameters": {
+                        "commandLine": [
+                            "./output_neglecting_command"
+                        ], 
+                        "user": "", 
+                        "workingDirectory": ""
+                    }, 
+                    "service": "shell-command"
+                }
+            ]
+        }
+    }
+}

--- a/tests/api/v1/system_tests/output_neglecting_command/workflow_executions.json
+++ b/tests/api/v1/system_tests/output_neglecting_command/workflow_executions.json
@@ -1,0 +1,155 @@
+{
+    "executions": [
+        {
+            "begins": [], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/1", 
+            "id": 1, 
+            "parentColor": null, 
+            "status": "failed", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-07-17 21:55:13.730024+00:00"
+                }, 
+                {
+                    "status": "failed", 
+                    "timestamp": "2015-07-17 21:55:15.947638+00:00"
+                }
+            ], 
+            "taskId": 2
+        }, 
+        {
+            "begins": [
+                0
+            ], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/2", 
+            "id": 2, 
+            "methodId": 1, 
+            "parentColor": null, 
+            "status": "failed", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-07-17 21:55:14.647901+00:00"
+                }, 
+                {
+                    "status": "scheduled", 
+                    "timestamp": "2015-07-17 21:55:14.816312+00:00"
+                }, 
+                {
+                    "status": "running", 
+                    "timestamp": "2015-07-17 21:55:14.816312+00:00"
+                }, 
+                {
+                    "status": "failed", 
+                    "timestamp": "2015-07-17 21:55:15.905536+00:00"
+                }
+            ]
+        }, 
+        {
+            "begins": [
+                0
+            ], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/3", 
+            "id": 3, 
+            "parentColor": null, 
+            "status": "succeeded", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-07-17 21:55:14.736594+00:00"
+                }, 
+                {
+                    "status": "scheduled", 
+                    "timestamp": "2015-07-17 21:55:14.736594+00:00"
+                }, 
+                {
+                    "status": "running", 
+                    "timestamp": "2015-07-17 21:55:14.736594+00:00"
+                }, 
+                {
+                    "status": "succeeded", 
+                    "timestamp": "2015-07-17 21:55:14.887778+00:00"
+                }
+            ], 
+            "taskId": 5
+        }, 
+        {
+            "begins": [
+                0
+            ], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/4", 
+            "id": 4, 
+            "parentColor": null, 
+            "status": "failed", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-07-17 21:55:14.939532+00:00"
+                }, 
+                {
+                    "status": "scheduled", 
+                    "timestamp": "2015-07-17 21:55:14.939532+00:00"
+                }, 
+                {
+                    "status": "running", 
+                    "timestamp": "2015-07-17 21:55:14.939532+00:00"
+                }, 
+                {
+                    "status": "failed", 
+                    "timestamp": "2015-07-17 21:55:15.856234+00:00"
+                }
+            ], 
+            "taskId": 4
+        }, 
+        {
+            "begins": [
+                0
+            ], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/5", 
+            "id": 5, 
+            "methodId": 2, 
+            "parentColor": null, 
+            "status": "errored", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-07-17 21:55:15.006231+00:00"
+                }, 
+                {
+                    "status": "scheduled", 
+                    "timestamp": "2015-07-17 21:55:15.091545+00:00"
+                }, 
+                {
+                    "status": "running", 
+                    "timestamp": "2015-07-17 21:55:15.637883+00:00"
+                }, 
+                {
+                    "status": "errored", 
+                    "timestamp": "2015-07-17 21:55:15.763400+00:00"
+                }
+            ]
+        }
+    ], 
+    "updateUrl": "http://localhost:7000/v1/reports/workflow-executions?workflow_id=1&since=2015-07-17+21%3A55%3A15.947638"
+}

--- a/tests/api/v1/system_tests/output_neglecting_command/workflow_skeleton.json
+++ b/tests/api/v1/system_tests/output_neglecting_command/workflow_skeleton.json
@@ -1,0 +1,19 @@
+{
+    "id": 1, 
+    "name": "GktOeQNJQKKyYaXTAyM4Vw", 
+    "rootTaskId": 2, 
+    "status": "failed", 
+    "tasks": {
+        "A": {
+            "id": 4, 
+            "methods": [
+                {
+                    "id": 2, 
+                    "name": "execute", 
+                    "service": "shell-command"
+                }
+            ], 
+            "topologicalIndex": 0
+        }
+    }
+}

--- a/tests/scripts/output_neglecting_command
+++ b/tests/scripts/output_neglecting_command
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import os
+import requests
+import sys
+
+def patch_and_expect(execution_url, patch_data, status_code):
+    print "Sending PATCH to %s with body: %s" % (execution_url, patch_data)
+    response = requests.patch(execution_url, json=patch_data)
+    if (response.status_code != status_code):
+        print "Expected status_code %s, but recieved %s instead." % (status_code,
+                response.status_code)
+        sys.exit(3)
+    else:
+        return response.json();
+
+def test_setting_only_some_outputs_fails(execution_url, all_outputs):
+    sent_outputs = all_outputs.copy()
+    output_names = sorted(all_outputs.keys())
+    del sent_outputs[output_names[0]]
+    patch_data = {'outputs': sent_outputs}
+    patch_and_expect(execution_url, patch_data, 409)
+
+def main():
+    execution_url = os.environ['PTERO_WORKFLOW_EXECUTION_URL']
+    print "Found PTERO_WORKFLOW_EXECUTION_URL = %s" % execution_url
+
+    execution_data = requests.get(execution_url).json()
+    print "Found execution_data from GET request = %s" % execution_data
+    inputs = execution_data['inputs']
+
+    test_setting_only_some_outputs_fails(execution_url, inputs)
+
+    sys.exit(os.EX_OK)
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/update_command
+++ b/tests/scripts/update_command
@@ -18,8 +18,22 @@ def test_inputs_cannot_be_set(execution_url):
     patch_data = {'inputs': {'foo': 'bar'}}
     patch_and_expect(execution_url, patch_data, 409)
 
-def test_outputs_cannot_be_set_more_than_once(execution_url):
+def test_outputs_cannot_be_set_if_incomplete(execution_url, outputs):
     patch_data = {'outputs': {'foo': 'bar'}}
+    patch_and_expect(execution_url, patch_data, 409)
+
+def test_outputs_can_be_set(execution_url, outputs):
+    patch_data = {'outputs': outputs}
+    patch_and_expect(execution_url, patch_data, 200)
+
+def test_outputs_cannot_be_set_more_than_once_unless_identical(
+        execution_url, outputs):
+    patch_data = {'outputs': outputs}
+    patch_and_expect(execution_url, patch_data, 200)
+
+    submitted_outputs = outputs.copy()
+    submitted_outputs['foo'] = 'bar'
+    patch_data = {'outputs': submitted_outputs}
     patch_and_expect(execution_url, patch_data, 409)
 
 def test_status_can_be_set(execution_url):
@@ -44,11 +58,13 @@ def main():
     print "Found execution_data from GET request = %s" % execution_data
     inputs = execution_data['inputs']
 
-    patch_data = {'outputs': inputs}
-    patch_and_expect(execution_url, patch_data, 200)
-
     test_inputs_cannot_be_set(execution_url)
-    test_outputs_cannot_be_set_more_than_once(execution_url)
+
+    test_outputs_cannot_be_set_if_incomplete(execution_url, inputs)
+    test_outputs_can_be_set(execution_url, inputs)
+    test_outputs_cannot_be_set_more_than_once_unless_identical(
+            execution_url, inputs)
+
     test_status_can_be_set(execution_url)
     test_data_can_be_updated(execution_url)
 


### PR DESCRIPTION
This will break the Genome Process tests until #165 is completed.  This is because the workflow created to update the status of the Process needs control-flow without data-flow to set the 'succeeded' status at the end.