### PR TITLE
Control flow

### DIFF
--- a/ptero_workflow/api/v1/schemas/post_workflow.json
+++ b/ptero_workflow/api/v1/schemas/post_workflow.json
@@ -175,17 +175,24 @@
         "link": {
             "type": "object",
             "properties": {
+                "dataFlow": { "$ref": "#/definitions/dataFlowDictionary" },
                 "destination": { "$ref": "#/definitions/name" },
-                "destinationProperty": { "$ref": "#/definitions/name" },
-                "source": { "$ref": "#/definitions/name" },
-                "sourceProperty": { "$ref": "#/definitions/name" }
+                "source": { "$ref": "#/definitions/name" }
             },
             "required": [
+                "dataFlow",
                 "destination",
-                "destinationProperty",
-                "source",
-                "sourceProperty"
+                "source"
             ],
+            "additionalProperties": false
+        },
+
+        "dataFlowDictionary": {
+            "type": "object",
+            "minProperties": 1,
+            "patternProperties": {
+                "^.+$": { "$ref": "#/definitions/name" }
+            },
             "additionalProperties": false
         }
     }

--- a/ptero_workflow/api/v1/schemas/post_workflow.json
+++ b/ptero_workflow/api/v1/schemas/post_workflow.json
@@ -191,9 +191,18 @@
             "type": "object",
             "minProperties": 1,
             "patternProperties": {
-                "^.+$": { "$ref": "#/definitions/name" }
+                "^.+$": { "$ref": "#/definitions/dataFlowEntry" }
             },
             "additionalProperties": false
+        },
+        "dataFlowEntry": { "oneOf": [
+            { "$ref": "#/definitions/name" },
+            { "$ref": "#/definitions/nameList" }
+        ]},
+        "nameList": {
+            "type": "array",
+            "items": { "$ref": "#/definitions/name" },
+            "minItems": 1
         }
     }
 }

--- a/ptero_workflow/api/v1/schemas/post_workflow.json
+++ b/ptero_workflow/api/v1/schemas/post_workflow.json
@@ -180,7 +180,6 @@
                 "source": { "$ref": "#/definitions/name" }
             },
             "required": [
-                "dataFlow",
                 "destination",
                 "source"
             ],

--- a/ptero_workflow/api/v1/views.py
+++ b/ptero_workflow/api/v1/views.py
@@ -4,6 +4,7 @@ from ...implementation import exceptions
 from flask import g, request, url_for
 from flask.ext.restful import Resource
 from jsonschema import ValidationError
+from ...implementation.exceptions import ValidationError as PteroValidationError
 from ptero_common.logging_configuration import logged_response
 from functools import wraps
 
@@ -62,7 +63,7 @@ class WorkflowListView(Resource):
             msg = "JSON schema validation error: %s" % e.message
             LOG.error(msg)
             return {'error': msg}, 400
-        except exceptions.InvalidWorkflow as e:
+        except PteroValidationError as e:
             LOG.exception(e)
             return {'error': e.message}, 400
 

--- a/ptero_workflow/implementation/backend.py
+++ b/ptero_workflow/implementation/backend.py
@@ -94,10 +94,11 @@ class Backend(object):
 
         for link_data in workflow_data['links']:
             if 'output connector' == link_data['destination']:
-                self.session.add(models.Link(source_task=workflow.root_task,
-                        source_property=link_data['destinationProperty'],
-                        destination_task=dummy_output_task,
-                        destination_property=link_data['destinationProperty']))
+                for source_property, destination_property in link_data['dataFlow'].items():
+                    self.session.add(models.Link(source_task=workflow.root_task,
+                            source_property=destination_property,
+                            destination_task=dummy_output_task,
+                            destination_property=destination_property))
 
         self.session.add(workflow)
         self.session.commit()
@@ -113,7 +114,7 @@ class Backend(object):
         required_inputs = set()
         for link in workflow_data['links']:
             if link['source'] == 'input connector':
-                required_inputs.add(link['sourceProperty'])
+                required_inputs.update(link['dataFlow'].keys())
 
         supplied_inputs = set(workflow_data['inputs'].keys())
         missing_inputs = required_inputs - supplied_inputs

--- a/ptero_workflow/implementation/backend.py
+++ b/ptero_workflow/implementation/backend.py
@@ -99,7 +99,7 @@ class Backend(object):
         self.session.add(link)
         for link_data in workflow_data['links']:
             if 'output connector' == link_data['destination']:
-                for source_property, destination_part in link_data['dataFlow'].items():
+                for source_property, destination_part in link_data.get('dataFlow', {}).items():
                     if isinstance(destination_part, basestring):
                         self.session.add(models.DataFlowEntry(source_property=destination_part,
                             destination_property=destination_part,
@@ -124,7 +124,7 @@ class Backend(object):
         required_inputs = set()
         for link in workflow_data['links']:
             if link['source'] == 'input connector':
-                required_inputs.update(link['dataFlow'].keys())
+                required_inputs.update(link.get('dataFlow', {}).keys())
 
         supplied_inputs = set(workflow_data['inputs'].keys())
         missing_inputs = required_inputs - supplied_inputs

--- a/ptero_workflow/implementation/exceptions.py
+++ b/ptero_workflow/implementation/exceptions.py
@@ -1,6 +1,3 @@
-class InvalidWorkflow(Exception):
-    pass
-
 class UpdateError(Exception):
     pass
 
@@ -20,4 +17,25 @@ class NoSuchEntityError(RuntimeError):
     pass
 
 class MissingResultError(RuntimeError):
+    pass
+
+class ValidationError(Exception):
+    pass
+
+class NonUniqueLinkError(ValidationError):
+    pass
+
+class NonUniqueNameError(ValidationError):
+    pass
+
+class MissingInputsError(ValidationError):
+    pass
+
+class UnknownIntegrityError(ValidationError):
+    pass
+
+class DAGCycleError(ValidationError):
+    pass
+
+class IllegalTaskNameError(ValidationError):
     pass

--- a/ptero_workflow/implementation/models/execution/method_execution.py
+++ b/ptero_workflow/implementation/models/execution/method_execution.py
@@ -29,13 +29,9 @@ class MethodExecution(Execution):
         return self.method.task.get_outputs(color=self.color)
 
     @property
-    def outputs_are_set(self):
-        return self.method.task.outputs_for_color_are_set(self.color)
-
-    @property
     def missing_outputs(self):
         outputs = self.get_outputs()
         if outputs is not None:
-            return self.method.task.output_properties - set(self.get_outputs())
+            return self.method.task.output_names - set(self.get_outputs())
         else:
-            return self.method.task.output_properties
+            return self.method.task.output_names

--- a/ptero_workflow/implementation/models/link.py
+++ b/ptero_workflow/implementation/models/link.py
@@ -40,8 +40,9 @@ class Link(Base):
         data = {
             'source': self.source_task.name,
             'destination': self.destination_task.name,
-            'sourceProperty': self.source_property,
-            'destinationProperty': self.destination_property,
+            'dataFlow': {
+                self.source_property: self.destination_property,
+            },
         }
         return data
 

--- a/ptero_workflow/implementation/models/link.py
+++ b/ptero_workflow/implementation/models/link.py
@@ -39,8 +39,9 @@ class Link(Base):
         data = {
             'source': self.source_task.name,
             'destination': self.destination_task.name,
-            'dataFlow': format_dict_of_lists(self.data_flow),
         }
+        if self.data_flow:
+            data['dataFlow'] = format_dict_of_lists(self.data_flow)
         return data
 
     @property

--- a/ptero_workflow/implementation/models/link.py
+++ b/ptero_workflow/implementation/models/link.py
@@ -2,10 +2,13 @@ from .base import Base
 from sqlalchemy import Column, UniqueConstraint, Index
 from sqlalchemy import Boolean, ForeignKey, Integer, Text
 from sqlalchemy.orm import backref, relationship
+from collections import defaultdict
+from ptero_common.utils import format_dict_of_lists
+
 import logging
 
 
-__all__ = ['Link']
+__all__ = ['Link', 'DataFlowEntry']
 
 
 LOG = logging.getLogger(__name__)
@@ -14,8 +17,7 @@ LOG = logging.getLogger(__name__)
 class Link(Base):
     __tablename__ = 'link'
     __table_args__ = (
-        UniqueConstraint('destination_id', 'destination_property'),
-        Index('destination_id', 'destination_property'),
+        UniqueConstraint('source_id', 'destination_id'),
     )
 
     id = Column(Integer, primary_key=True)
@@ -24,9 +26,6 @@ class Link(Base):
             nullable=False)
     destination_id = Column(Integer, ForeignKey('task.id'), index=True,
             nullable=False)
-
-    source_property      = Column(Text, nullable=False)
-    destination_property = Column(Text, nullable=False)
 
     source_task = relationship('Task',
             backref=backref('output_links'),
@@ -40,10 +39,33 @@ class Link(Base):
         data = {
             'source': self.source_task.name,
             'destination': self.destination_task.name,
-            'dataFlow': {
-                self.source_property: self.destination_property,
-            },
+            'dataFlow': format_dict_of_lists(self.data_flow),
         }
         return data
 
+    @property
+    def data_flow(self):
+        result = defaultdict(list)
+
+        for entry in self.data_flow_entries:
+            result[entry.source_property].append(entry.destination_property)
+
+        return result
+
     as_skeleton_dict = as_dict
+
+class DataFlowEntry(Base):
+    __tablename__ = 'data_flow_entry'
+    __table_args__ = (
+        UniqueConstraint('link_id', 'source_property', 'destination_property'),
+    )
+
+    id = Column(Integer, primary_key=True)
+
+    link_id = Column(Integer, ForeignKey('link.id'), index=True,
+            nullable=False)
+
+    source_property = Column(Text, nullable=False)
+    destination_property = Column(Text, nullable=False)
+
+    link = relationship('Link', backref=backref('data_flow_entries', lazy='joined'))

--- a/ptero_workflow/implementation/models/methods/shell_command.py
+++ b/ptero_workflow/implementation/models/methods/shell_command.py
@@ -110,7 +110,12 @@ class ShellCommand(Method):
     def succeeded(self, body_data, query_string_data):
         execution = self._get_execution(query_string_data['execution_id'])
 
-        if execution.outputs_are_set:
+        missing_outputs = execution.missing_outputs
+        if execution.missing_outputs:
+            execution.data['error'] = 'Command failed to set required outputs %s' %\
+                    sorted(execution.missing_outputs)
+            self.errored(body_data, query_string_data)
+        else:
             execution.status = succeeded
             execution.data.update(body_data)
 
@@ -120,10 +125,6 @@ class ShellCommand(Method):
             response_url = execution.data['petri_response_links_for_shell_command']['success']
 
             self.http.delay('PUT', response_url)
-        else:
-            execution.data['error'] = 'Command failed to set required outputs %s' %\
-                    sorted(execution.missing_outputs)
-            self.errored(body_data, query_string_data)
 
     def failed(self, body_data, query_string_data):
         execution = self._get_execution(query_string_data['execution_id'])

--- a/ptero_workflow/implementation/models/task/task_base.py
+++ b/ptero_workflow/implementation/models/task/task_base.py
@@ -540,11 +540,6 @@ class Task(Base, PetriMixin):
         if results:
             return {r.name: r.data for r in results}
 
-    def outputs_for_color_are_set(self, color):
-        s = object_session(self)
-        num_results = s.query(result.Result).filter_by(task=self, color=color).count()
-        return num_results > 0
-
 def _get_parent_color(colors):
     if len(colors) == 1:
         return None

--- a/ptero_workflow/implementation/models/task/task_base.py
+++ b/ptero_workflow/implementation/models/task/task_base.py
@@ -350,11 +350,19 @@ class Task(Base, PetriMixin):
 
     @property
     def input_names(self):
-        return [e.destination_property for e in self.input_links]
+        result = set()
+        for link in self.input_links:
+            for entry in link.data_flow_entries:
+                result.add(entry.destination_property)
+        return result
 
     @property
     def output_names(self):
-        return [e.source_property for e in self.output_links]
+        result = set()
+        for link in self.output_links:
+            for entry in link.data_flow_entries:
+                result.add(entry.source_property)
+        return result
 
     @classmethod
     def from_dict(cls, type, **kwargs):
@@ -399,19 +407,17 @@ class Task(Base, PetriMixin):
         else:
             return []
 
-    @property
-    def output_properties(self):
-        return set([l.source_property for l in self.output_links])
-
     def set_outputs(self, outputs, color, parent_color):
-        for output_property in self.output_properties:
-            if output_property not in outputs.keys():
+        for output_name in self.output_names:
+            if output_name not in outputs.keys():
                 raise exceptions.MissingOutputError(
-                        "No value specified for output (%s), outputs specified were: %s" %
-                        (output_property, str(outputs.keys())))
+                        "No value specified for output (%s) on task (%s:%s), "
+                        "outputs specified were: %s" % (output_name, self.name,
+                            self.id, str(outputs.keys())))
             else:
-                result.Result(task=self, name=output_property, data=outputs[output_property],
-                        color=color, parent_color=parent_color)
+                result.Result(task=self, name=output_name,
+                        data=outputs[output_name], color=color,
+                        parent_color=parent_color)
 
     def get_inputs(self, colors, begins):
         inputs = {}
@@ -491,10 +497,11 @@ class Task(Base, PetriMixin):
         else:
             pdepths = parallel_depths
 
-        for e in self.input_links:
-            if e.destination_property == name:
-                return e.source_task.resolve_output_source(session,
-                        e.source_property, pdepths)
+        for input_link in self.input_links:
+            for source, destination_list in input_link.data_flow.iteritems():
+                if name in destination_list:
+                    return input_link.source_task.resolve_output_source(session,
+                            source, pdepths)
 
     def resolve_output_source(self, session, name, parallel_depths):
         return self, name, parallel_depths
@@ -502,24 +509,25 @@ class Task(Base, PetriMixin):
     def create_input_sources(self, session, parallel_depths):
         LOG.debug('%s - Creating input sources for %s', self.workflow_id, 
                 self.name)
-        for e in self.input_links:
-            source_task, source_property, source_parallel_depths = \
-                    self.resolve_input_source(session, e.destination_property,
-                            parallel_depths)
-            LOG.debug('%s - Found input source %s[%s] = %s[%s]: parallel_depths=%s',
-                    self.workflow_id, self.name, e.destination_property,
-                    source_task.name, source_property,
-                    source_parallel_depths)
+        for input_link in self.input_links:
+            for entry in input_link.data_flow_entries:
+                source_task, source_property, source_parallel_depths = \
+                        self.resolve_input_source(session, entry.destination_property,
+                                parallel_depths)
+                LOG.debug('%s - Found input source %s[%s] = %s[%s]: parallel_depths=%s',
+                        self.workflow_id, self.name, entry.destination_property,
+                        source_task.name, entry.source_property,
+                        source_parallel_depths)
 
-            in_source = input_source.InputSource(
-                    source_task=source_task,
-                    source_property=source_property,
-                    destination_task=self,
-                    destination_property=e.destination_property,
-                    parallel_depths=source_parallel_depths,
-                    workflow=self.workflow,
-            )
-            session.add(in_source)
+                in_source = input_source.InputSource(
+                        source_task=source_task,
+                        source_property=source_property,
+                        destination_task=self,
+                        destination_property=entry.destination_property,
+                        parallel_depths=source_parallel_depths,
+                        workflow=self.workflow,
+                )
+                session.add(in_source)
 
     @property
     def http(self):

--- a/ptero_workflow/implementation/models/workflow.py
+++ b/ptero_workflow/implementation/models/workflow.py
@@ -6,7 +6,6 @@ import logging
 import json
 import os
 import uuid
-from collections import defaultdict
 
 
 __all__ = ['Workflow']
@@ -55,30 +54,8 @@ class Workflow(Base):
 
         return sorted(results,
                 key=lambda l: l.source_task.name\
-                    + l.destination_task.name\
-                    + l.source_property\
-                    + l.destination_property)
+                    + l.destination_task.name)
         return results
-
-    @property
-    def links_dict_list(self):
-        link_entries = defaultdict(list)
-        for link in self.links:
-            key = str([link.source_task.name, link.destination_task.name])
-            link_entries[key].append(link)
-
-        result = []
-        for link_entry_key in sorted(link_entries.keys()):
-            link_entry = link_entries[link_entry_key]
-
-            first_link = link_entry.pop()
-            entry = first_link.as_dict().copy()
-            for additional_link in link_entry:
-                entry['dataFlow'][additional_link.source_property] =\
-                        additional_link.destination_property
-            result.append(entry)
-
-        return result
 
     @property
     def tasks(self):
@@ -114,7 +91,7 @@ class Workflow(Base):
 
         result = {
             'tasks': tasks,
-            'links': self.links_dict_list,
+            'links': [l.as_dict(detailed=detailed) for l in self.links],
             'inputs': self.root_task.get_inputs(colors=[0], begins=[0]),
             'status': self.status,
             'name': self.name,

--- a/ptero_workflow/implementation/tasks.py
+++ b/ptero_workflow/implementation/tasks.py
@@ -73,14 +73,15 @@ def _build_dag_method(data, workflow, index, parent_task):
     method.children = children
 
     for link_data in data['parameters']['links']:
-        source = children[link_data['source']]
-        destination = children[link_data['destination']]
-        models.Link(
-            destination_task=destination,
-            destination_property=link_data['destinationProperty'],
-            source_task=source,
-            source_property=link_data['sourceProperty'],
-        )
+        for source_property, destination_property in link_data['dataFlow'].items():
+            source = children[link_data['source']]
+            destination = children[link_data['destination']]
+            models.Link(
+                destination_task=destination,
+                destination_property=destination_property,
+                source_task=source,
+                source_property=source_property,
+            )
 
     return method
 

--- a/ptero_workflow/implementation/tasks.py
+++ b/ptero_workflow/implementation/tasks.py
@@ -81,7 +81,7 @@ def _build_dag_method(data, workflow, index, parent_task):
             destination_task=destination,
             source_task=source,
         )
-        for source_property, destination_part in link_data['dataFlow'].items():
+        for source_property, destination_part in link_data.get('dataFlow', {}).items():
             if isinstance(destination_part, basestring):
                 models.DataFlowEntry(source_property=source_property,
                     destination_property=destination_part,

--- a/ptero_workflow/implementation/validators.py
+++ b/ptero_workflow/implementation/validators.py
@@ -1,0 +1,22 @@
+from collections import defaultdict
+from .exceptions import NonUniqueLinkError
+import logging
+
+LOG = logging.getLogger(__name__)
+
+def validate_unique_links(links):
+    link_counts = defaultdict(lambda:0)
+    for link in links:
+        key = str({
+            'source': link['source'],
+            'destination': link['destination']
+            })
+        link_counts[key] += 1
+
+    violations = []
+    for link_key, count in link_counts.iteritems():
+        if count > 1:
+            violations.append(link_key)
+
+    if violations:
+        raise NonUniqueLinkError("Found non-uniq link entries for: %s" % str(violations))

--- a/tests/api/base.py
+++ b/tests/api/base.py
@@ -89,5 +89,9 @@ class BaseAPITest(unittest.TestCase):
 
 
 def _deserialize_response(response):
-    response.DATA = response.json()
+    try:
+        response.DATA = response.json()
+    except ValueError:
+        print "No JSON could be decoded from response to %s %s" % (
+                response.request.method, response.request.url)
     return response

--- a/tests/api/v1/regression_tests/parallel_by_operation_multiple_inputs/submit.json
+++ b/tests/api/v1/regression_tests/parallel_by_operation_multiple_inputs/submit.json
@@ -35,33 +35,38 @@
         {
             "source": "input connector",
             "destination": "intermediate",
-            "sourceProperty": "in_constant",
-            "destinationProperty": "constant_param"
+            "dataFlow": {
+                "in_constant": "constant_param"
+            }
         },
         {
             "source": "intermediate",
             "destination": "A",
-            "sourceProperty": "constant_param",
-            "destinationProperty": "constant_param"
+            "dataFlow": {
+                "constant_param": "constant_param"
+            }
         },
         {
             "source": "A",
             "destination": "output connector",
-            "sourceProperty": "constant_param",
-            "destinationProperty": "out_constant"
+            "dataFlow": {
+                "constant_param": "out_constant"
+            }
         },
 
         {
             "source": "input connector",
             "destination": "A",
-            "sourceProperty": "in_parallel",
-            "destinationProperty": "parallel_param"
+            "dataFlow": {
+                "in_parallel": "parallel_param"
+            }
         },
         {
             "source": "A",
             "destination": "output connector",
-            "sourceProperty": "parallel_param",
-            "destinationProperty": "out_parallel"
+            "dataFlow": {
+                "parallel_param": "out_parallel"
+            }
         }
     ],
 

--- a/tests/api/v1/regression_tests/parallel_by_operation_multiple_inputs/submit.json
+++ b/tests/api/v1/regression_tests/parallel_by_operation_multiple_inputs/submit.json
@@ -50,7 +50,8 @@
             "source": "A",
             "destination": "output connector",
             "dataFlow": {
-                "constant_param": "out_constant"
+                "constant_param": "out_constant",
+                "parallel_param": "out_parallel"
             }
         },
 
@@ -59,13 +60,6 @@
             "destination": "A",
             "dataFlow": {
                 "in_parallel": "parallel_param"
-            }
-        },
-        {
-            "source": "A",
-            "destination": "output connector",
-            "dataFlow": {
-                "parallel_param": "out_parallel"
             }
         }
     ],

--- a/tests/api/v1/regression_tests/parallel_by_operation_multiple_outputs/submit.json
+++ b/tests/api/v1/regression_tests/parallel_by_operation_multiple_outputs/submit.json
@@ -49,40 +49,46 @@
         {
             "source": "input connector",
             "destination": "start",
-            "sourceProperty": "in_constant",
-            "destinationProperty": "constant_param"
+            "dataFlow": {
+                "in_constant": "constant_param"
+            }
         },
         {
             "source": "start",
             "destination": "stop",
-            "sourceProperty": "constant_param",
-            "destinationProperty": "constant_param"
+            "dataFlow": {
+                "constant_param": "constant_param"
+            }
         },
 
         {
             "source": "input connector",
             "destination": "middle",
-            "sourceProperty": "in_parallel",
-            "destinationProperty": "parallel_param"
+            "dataFlow": {
+                "in_parallel": "parallel_param"
+            }
         },
         {
             "source": "middle",
             "destination": "stop",
-            "sourceProperty": "parallel_param",
-            "destinationProperty": "parallel_param"
+            "dataFlow": {
+                "parallel_param": "parallel_param"
+            }
         },
 
         {
             "source": "stop",
             "destination": "output connector",
-            "sourceProperty": "constant_param",
-            "destinationProperty": "out_constant"
+            "dataFlow": {
+                "constant_param": "out_constant"
+            }
         },
         {
             "source": "stop",
             "destination": "output connector",
-            "sourceProperty": "parallel_param",
-            "destinationProperty": "out_parallel"
+            "dataFlow": {
+                "parallel_param": "out_parallel"
+            }
         }
     ],
 

--- a/tests/api/v1/regression_tests/parallel_by_operation_multiple_outputs/submit.json
+++ b/tests/api/v1/regression_tests/parallel_by_operation_multiple_outputs/submit.json
@@ -80,13 +80,7 @@
             "source": "stop",
             "destination": "output connector",
             "dataFlow": {
-                "constant_param": "out_constant"
-            }
-        },
-        {
-            "source": "stop",
-            "destination": "output connector",
-            "dataFlow": {
+                "constant_param": "out_constant",
                 "parallel_param": "out_parallel"
             }
         }

--- a/tests/api/v1/system_tests/control_flow/result.json
+++ b/tests/api/v1/system_tests/control_flow/result.json
@@ -1,0 +1,3 @@
+{
+    "outputs": null
+}

--- a/tests/api/v1/system_tests/control_flow/submit.json
+++ b/tests/api/v1/system_tests/control_flow/submit.json
@@ -1,0 +1,53 @@
+{
+    "tasks": {
+        "A": {
+            "methods": [
+                {
+                    "name": "execute",
+                    "service": "shell-command",
+                    "parameters": {
+                        "commandLine": ["./create_delete_file_command"],
+                        "user": "{{ user }}",
+                        "workingDirectory": "{{ workingDirectory }}",
+                        "environment": {{ environment }}
+                    }
+                }
+            ]
+        },
+        "B": {
+            "methods": [
+                {
+                    "name": "execute",
+                    "service": "shell-command",
+                    "parameters": {
+                        "commandLine": ["./create_delete_file_command"],
+                        "user": "{{ user }}",
+                        "workingDirectory": "{{ workingDirectory }}",
+                        "environment": {{ environment }}
+                    }
+                }
+            ]
+        }
+    },
+
+    "links": [
+        {
+            "source": "input connector",
+            "destination": "A"
+        },
+        {
+            "source": "A",
+            "destination": "B",
+            "dataFlow": {
+                "filename": "filename"
+            }
+        },
+        {
+            "source": "B",
+            "destination": "output connector"
+        }
+    ],
+
+    "inputs": {
+    }
+}

--- a/tests/api/v1/system_tests/control_flow/workflow_details.json
+++ b/tests/api/v1/system_tests/control_flow/workflow_details.json
@@ -1,0 +1,69 @@
+{
+    "inputs": {}, 
+    "links": [
+        {
+            "dataFlow": {
+                "filename": "filename"
+            }, 
+            "destination": "B", 
+            "source": "A"
+        }, 
+        {
+            "destination": "output connector", 
+            "source": "B"
+        }, 
+        {
+            "destination": "A", 
+            "source": "input connector"
+        }
+    ], 
+    "status": "succeeded", 
+    "tasks": {
+        "A": {
+            "executions": {
+                "0": {
+                    "status": "succeeded"
+                }
+            }, 
+            "methods": [
+                {
+                    "executions": {
+                        "0": {
+                            "status": "succeeded"
+                        }
+                    }, 
+                    "name": "execute", 
+                    "parameters": {
+                        "commandLine": [
+                            "./create_delete_file_command"
+                        ]
+                    }, 
+                    "service": "shell-command"
+                }
+            ]
+        }, 
+        "B": {
+            "executions": {
+                "0": {
+                    "status": "succeeded"
+                }
+            }, 
+            "methods": [
+                {
+                    "executions": {
+                        "0": {
+                            "status": "succeeded"
+                        }
+                    }, 
+                    "name": "execute", 
+                    "parameters": {
+                        "commandLine": [
+                            "./create_delete_file_command"
+                        ]
+                    }, 
+                    "service": "shell-command"
+                }
+            ]
+        }
+    }
+}

--- a/tests/api/v1/system_tests/control_flow/workflow_executions.json
+++ b/tests/api/v1/system_tests/control_flow/workflow_executions.json
@@ -1,0 +1,251 @@
+{
+    "executions": [
+        {
+            "begins": [], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/1", 
+            "id": 1, 
+            "parentColor": null, 
+            "status": "succeeded", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-07-21 04:31:18.704447+00:00"
+                }, 
+                {
+                    "status": "succeeded", 
+                    "timestamp": "2015-07-21 04:31:22.583781+00:00"
+                }
+            ], 
+            "taskId": 2
+        }, 
+        {
+            "begins": [
+                0
+            ], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/2", 
+            "id": 2, 
+            "methodId": 1, 
+            "parentColor": null, 
+            "status": "succeeded", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-07-21 04:31:20.101496+00:00"
+                }, 
+                {
+                    "status": "scheduled", 
+                    "timestamp": "2015-07-21 04:31:20.260557+00:00"
+                }, 
+                {
+                    "status": "running", 
+                    "timestamp": "2015-07-21 04:31:20.260557+00:00"
+                }, 
+                {
+                    "status": "succeeded", 
+                    "timestamp": "2015-07-21 04:31:22.542023+00:00"
+                }
+            ]
+        }, 
+        {
+            "begins": [
+                0
+            ], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/3", 
+            "id": 3, 
+            "parentColor": null, 
+            "status": "succeeded", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-07-21 04:31:20.178128+00:00"
+                }, 
+                {
+                    "status": "scheduled", 
+                    "timestamp": "2015-07-21 04:31:20.178128+00:00"
+                }, 
+                {
+                    "status": "running", 
+                    "timestamp": "2015-07-21 04:31:20.178128+00:00"
+                }, 
+                {
+                    "status": "succeeded", 
+                    "timestamp": "2015-07-21 04:31:20.341716+00:00"
+                }
+            ], 
+            "taskId": 4
+        }, 
+        {
+            "begins": [
+                0
+            ], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/4", 
+            "id": 4, 
+            "parentColor": null, 
+            "status": "succeeded", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-07-21 04:31:20.393246+00:00"
+                }, 
+                {
+                    "status": "scheduled", 
+                    "timestamp": "2015-07-21 04:31:20.393246+00:00"
+                }, 
+                {
+                    "status": "running", 
+                    "timestamp": "2015-07-21 04:31:20.393246+00:00"
+                }, 
+                {
+                    "status": "succeeded", 
+                    "timestamp": "2015-07-21 04:31:21.361131+00:00"
+                }
+            ], 
+            "taskId": 7
+        }, 
+        {
+            "begins": [
+                0
+            ], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/5", 
+            "id": 5, 
+            "methodId": 3, 
+            "parentColor": null, 
+            "status": "succeeded", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-07-21 04:31:20.488281+00:00"
+                }, 
+                {
+                    "status": "scheduled", 
+                    "timestamp": "2015-07-21 04:31:20.560841+00:00"
+                }, 
+                {
+                    "status": "running", 
+                    "timestamp": "2015-07-21 04:31:21.097869+00:00"
+                }, 
+                {
+                    "status": "succeeded", 
+                    "timestamp": "2015-07-21 04:31:21.263447+00:00"
+                }
+            ]
+        }, 
+        {
+            "begins": [
+                0
+            ], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/6", 
+            "id": 6, 
+            "parentColor": null, 
+            "status": "succeeded", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-07-21 04:31:21.420540+00:00"
+                }, 
+                {
+                    "status": "scheduled", 
+                    "timestamp": "2015-07-21 04:31:21.420540+00:00"
+                }, 
+                {
+                    "status": "running", 
+                    "timestamp": "2015-07-21 04:31:21.420540+00:00"
+                }, 
+                {
+                    "status": "succeeded", 
+                    "timestamp": "2015-07-21 04:31:22.297601+00:00"
+                }
+            ], 
+            "taskId": 6
+        }, 
+        {
+            "begins": [
+                0
+            ], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/7", 
+            "id": 7, 
+            "methodId": 2, 
+            "parentColor": null, 
+            "status": "succeeded", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-07-21 04:31:21.492580+00:00"
+                }, 
+                {
+                    "status": "scheduled", 
+                    "timestamp": "2015-07-21 04:31:21.607006+00:00"
+                }, 
+                {
+                    "status": "running", 
+                    "timestamp": "2015-07-21 04:31:22.139722+00:00"
+                }, 
+                {
+                    "status": "succeeded", 
+                    "timestamp": "2015-07-21 04:31:22.229320+00:00"
+                }
+            ]
+        }, 
+        {
+            "begins": [
+                0
+            ], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/8", 
+            "id": 8, 
+            "parentColor": null, 
+            "status": "succeeded", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-07-21 04:31:22.347813+00:00"
+                }, 
+                {
+                    "status": "scheduled", 
+                    "timestamp": "2015-07-21 04:31:22.347813+00:00"
+                }, 
+                {
+                    "status": "running", 
+                    "timestamp": "2015-07-21 04:31:22.347813+00:00"
+                }, 
+                {
+                    "status": "succeeded", 
+                    "timestamp": "2015-07-21 04:31:22.491914+00:00"
+                }
+            ], 
+            "taskId": 5
+        }
+    ], 
+    "updateUrl": "http://localhost:7000/v1/reports/workflow-executions?since=2015-07-21+04%3A31%3A22.583781&workflow_id=1"
+}

--- a/tests/api/v1/system_tests/control_flow/workflow_skeleton.json
+++ b/tests/api/v1/system_tests/control_flow/workflow_skeleton.json
@@ -1,0 +1,30 @@
+{
+    "id": 1, 
+    "name": "Zc6-zEgHRWmFEWbjrCdhPQ", 
+    "rootTaskId": 2, 
+    "status": "succeeded", 
+    "tasks": {
+        "A": {
+            "id": 7, 
+            "methods": [
+                {
+                    "id": 3, 
+                    "name": "execute", 
+                    "service": "shell-command"
+                }
+            ], 
+            "topologicalIndex": 0
+        }, 
+        "B": {
+            "id": 6, 
+            "methods": [
+                {
+                    "id": 2, 
+                    "name": "execute", 
+                    "service": "shell-command"
+                }
+            ], 
+            "topologicalIndex": 1
+        }
+    }
+}

--- a/tests/api/v1/system_tests/converge/submit.json
+++ b/tests/api/v1/system_tests/converge/submit.json
@@ -18,20 +18,17 @@
         {
             "source": "input connector",
             "destination": "A",
-            "sourceProperty": "in_a",
-            "destinationProperty": "a"
-        },
-        {
-            "source": "input connector",
-            "destination": "A",
-            "sourceProperty": "in_b",
-            "destinationProperty": "b"
+            "dataFlow": {
+                "in_a": "a",
+                "in_b": "b"
+            }
         },
         {
             "source": "A",
             "destination": "output connector",
-            "sourceProperty": "c",
-            "destinationProperty": "out_c"
+            "dataFlow": {
+                "c": "out_c"
+            }
         }
     ],
 

--- a/tests/api/v1/system_tests/n_shaped/submit.json
+++ b/tests/api/v1/system_tests/n_shaped/submit.json
@@ -62,58 +62,55 @@
         {
             "source": "input connector",
             "destination": "A",
-            "sourceProperty": "in_a_1",
-            "destinationProperty": "param_1"
-        },
-        {
-            "source": "input connector",
-            "destination": "A",
-            "sourceProperty": "in_a_2",
-            "destinationProperty": "param_2"
+            "dataFlow": {
+                "in_a_1": "param_1",
+                "in_a_2": "param_2"
+            }
         },
         {
             "source": "input connector",
             "destination": "B",
-            "sourceProperty": "in_b",
-            "destinationProperty": "param"
+            "dataFlow": {
+                "in_b": "param"
+            }
         },
 
         {
             "source": "A",
             "destination": "C",
-            "sourceProperty": "param_1",
-            "destinationProperty": "param"
+            "dataFlow": {
+                "param_1": "param"
+            }
         },
         {
             "source": "A",
             "destination": "D",
-            "sourceProperty": "param_2",
-            "destinationProperty": "param_1"
+            "dataFlow": {
+                "param_2": "param_1"
+            }
         },
         {
             "source": "B",
             "destination": "D",
-            "sourceProperty": "param",
-            "destinationProperty": "param_2"
+            "dataFlow": {
+                "param": "param_2"
+            }
         },
 
         {
             "source": "C",
             "destination": "output connector",
-            "sourceProperty": "param",
-            "destinationProperty": "out_c"
+            "dataFlow": {
+                "param": "out_c"
+            }
         },
         {
             "source": "D",
             "destination": "output connector",
-            "sourceProperty": "param_1",
-            "destinationProperty": "out_d_1"
-        },
-        {
-            "source": "D",
-            "destination": "output connector",
-            "sourceProperty": "param_2",
-            "destinationProperty": "out_d_2"
+            "dataFlow": {
+                "param_1": "out_d_1",
+                "param_2": "out_d_2"
+            }
         }
     ],
 

--- a/tests/api/v1/system_tests/n_shaped_with_block/submit.json
+++ b/tests/api/v1/system_tests/n_shaped_with_block/submit.json
@@ -72,76 +72,68 @@
         {
             "source": "input connector",
             "destination": "A",
-            "sourceProperty": "in_a_1",
-            "destinationProperty": "param_1"
-        },
-        {
-            "source": "input connector",
-            "destination": "A",
-            "sourceProperty": "in_a_2",
-            "destinationProperty": "param_2"
+            "dataFlow": {
+                "in_a_1": "param_1",
+                "in_a_2": "param_2"
+            }
         },
         {
             "source": "input connector",
             "destination": "B",
-            "sourceProperty": "in_b",
-            "destinationProperty": "param"
+            "dataFlow": {
+                "in_b": "param"
+            }
         },
-
         {
             "source": "A",
             "destination": "C",
-            "sourceProperty": "param_1",
-            "destinationProperty": "param"
+            "dataFlow": {
+                "param_1": "param"
+            }
         },
         {
             "source": "A",
             "destination": "D",
-            "sourceProperty": "param_2",
-            "destinationProperty": "param_1"
+            "dataFlow": {
+                "param_2": "param_1"
+            }
         },
         {
             "source": "B",
             "destination": "D",
-            "sourceProperty": "param",
-            "destinationProperty": "param_2"
+            "dataFlow": {
+                "param": "param_2"
+            }
         },
-
         {
             "source": "C",
             "destination": "output connector",
-            "sourceProperty": "param",
-            "destinationProperty": "out_c"
+            "dataFlow": {
+                "param": "out_c"
+            }
         },
         {
             "source": "D",
             "destination": "output connector",
-            "sourceProperty": "param_1",
-            "destinationProperty": "out_d_1"
-        },
-        {
-            "source": "D",
-            "destination": "output connector",
-            "sourceProperty": "param_2",
-            "destinationProperty": "out_d_2"
+            "dataFlow": {
+                "param_1": "out_d_1",
+                "param_2": "out_d_2"
+            }
         },
         {
             "source": "D",
             "destination": "Block",
-            "sourceProperty": "param_2",
-            "destinationProperty": "param_2"
+            "dataFlow": {
+                "param_2": "param_2"
+            }
         },
         {
             "source": "Block",
             "destination": "output connector",
-            "sourceProperty": "result",
-            "destinationProperty": "block_result"
-        },
-        {
-            "source": "Block",
-            "destination": "output connector",
-            "sourceProperty": "param_2",
-            "destinationProperty": "block_param_2"
+            "dataFlow": {
+                "result": "block_result",
+                "param_2": "block_param_2"
+            }
         }
     ],
 

--- a/tests/api/v1/system_tests/nested/submit.json
+++ b/tests/api/v1/system_tests/nested/submit.json
@@ -105,13 +105,7 @@
             "source": "C",
             "destination": "output connector",
             "dataFlow": {
-                "param_1": "outer_out_c_1"
-            }
-        },
-        {
-            "source": "C",
-            "destination": "output connector",
-            "dataFlow": {
+                "param_1": "outer_out_c_1",
                 "param_2": "outer_out_c_2"
             }
         }

--- a/tests/api/v1/system_tests/nested/submit.json
+++ b/tests/api/v1/system_tests/nested/submit.json
@@ -39,14 +39,16 @@
                             {
                                 "source": "input connector",
                                 "destination": "B",
-                                "sourceProperty": "inner_in_b",
-                                "destinationProperty": "param"
+                                "dataFlow": {
+                                    "inner_in_b": "param"
+                                }
                             },
                             {
                                 "source": "B",
                                 "destination": "output connector",
-                                "sourceProperty": "param",
-                                "destinationProperty": "inner_out_b"
+                                "dataFlow": {
+                                    "param": "inner_out_b"
+                                }
                             }
                         ]
                     },
@@ -74,38 +76,44 @@
         {
             "source": "input connector",
             "destination": "A",
-            "sourceProperty": "outer_in_a",
-            "destinationProperty": "param"
+            "dataFlow": {
+                "outer_in_a": "param"
+            }
         },
         {
             "source": "input connector",
             "destination": "Inner",
-            "sourceProperty": "outer_in_inner",
-            "destinationProperty": "inner_in_b"
+            "dataFlow": {
+                "outer_in_inner": "inner_in_b"
+            }
         },
         {
             "source": "A",
             "destination": "C",
-            "sourceProperty": "param",
-            "destinationProperty": "param_1"
+            "dataFlow": {
+                "param": "param_1"
+            }
         },
         {
             "source": "Inner",
             "destination": "C",
-            "sourceProperty": "inner_out_b",
-            "destinationProperty": "param_2"
+            "dataFlow": {
+                "inner_out_b": "param_2"
+            }
         },
         {
             "source": "C",
             "destination": "output connector",
-            "sourceProperty": "param_1",
-            "destinationProperty": "outer_out_c_1"
+            "dataFlow": {
+                "param_1": "outer_out_c_1"
+            }
         },
         {
             "source": "C",
             "destination": "output connector",
-            "sourceProperty": "param_2",
-            "destinationProperty": "outer_out_c_2"
+            "dataFlow": {
+                "param_2": "outer_out_c_2"
+            }
         }
     ],
 

--- a/tests/api/v1/system_tests/nested_parallel_by_dag_orthogonal_inputs/submit.json
+++ b/tests/api/v1/system_tests/nested_parallel_by_dag_orthogonal_inputs/submit.json
@@ -4,6 +4,7 @@
       "source": "input connector",
       "destination": "A",
       "dataFlow": {
+          "in_inner_parallel": "in_inner_parallel",
           "in_outer_parallel": "in_outer_parallel"
       }
     },
@@ -11,21 +12,8 @@
       "source": "A",
       "destination": "output connector",
       "dataFlow": {
+          "out_inner_parallel": "out_inner_parallel",
           "out_outer_parallel": "out_outer_parallel"
-      }
-    },
-    {
-      "source": "input connector",
-      "destination": "A",
-      "dataFlow": {
-          "in_inner_parallel": "in_inner_parallel"
-      }
-    },
-    {
-      "source": "A",
-      "destination": "output connector",
-      "dataFlow": {
-          "out_inner_parallel": "out_inner_parallel"
       }
     }
   ],
@@ -40,6 +28,7 @@
                 "source": "input connector",
                 "destination": "Inner",
                 "dataFlow": {
+                    "in_inner_parallel": "kitten_name_in",
                     "in_outer_parallel": "animal_type_in"
                 }
               },
@@ -47,21 +36,8 @@
                 "source": "Inner",
                 "destination": "output connector",
                 "dataFlow": {
+                    "kitten_name_out": "out_inner_parallel",
                     "animal_type_out": "out_outer_parallel"
-                }
-              },
-              {
-                "source": "input connector",
-                "destination": "Inner",
-                "dataFlow": {
-                    "in_inner_parallel": "kitten_name_in"
-                }
-              },
-              {
-                "source": "Inner",
-                "destination": "output connector",
-                "dataFlow": {
-                    "kitten_name_out": "out_inner_parallel"
                 }
               }
             ],
@@ -76,20 +52,7 @@
                           "source": "input connector",
                           "destination": "A",
                           "dataFlow": {
-                              "animal_type_in": "animal_type"
-                          }
-                        },
-                        {
-                          "source": "A",
-                          "destination": "output connector",
-                          "dataFlow": {
-                              "animal_type": "animal_type_out"
-                          }
-                        },
-                        {
-                          "source": "input connector",
-                          "destination": "A",
-                          "dataFlow": {
+                              "animal_type_in": "animal_type",
                               "kitten_name_in": "kitten_name"
                           }
                         },
@@ -97,6 +60,7 @@
                           "source": "A",
                           "destination": "output connector",
                           "dataFlow": {
+                              "animal_type": "animal_type_out",
                               "kitten_name": "kitten_name_out"
                           }
                         }

--- a/tests/api/v1/system_tests/nested_parallel_by_dag_orthogonal_inputs/submit.json
+++ b/tests/api/v1/system_tests/nested_parallel_by_dag_orthogonal_inputs/submit.json
@@ -1,28 +1,32 @@
 {
   "links": [
     {
-      "destination": "A",
-      "destinationProperty": "in_outer_parallel",
       "source": "input connector",
-      "sourceProperty": "in_outer_parallel"
-    },
-    {
-      "destination": "output connector",
-      "destinationProperty": "out_outer_parallel",
-      "source": "A",
-      "sourceProperty": "out_outer_parallel"
-    },
-    {
       "destination": "A",
-      "destinationProperty": "in_inner_parallel",
-      "source": "input connector",
-      "sourceProperty": "in_inner_parallel"
+      "dataFlow": {
+          "in_outer_parallel": "in_outer_parallel"
+      }
     },
     {
-      "destination": "output connector",
-      "destinationProperty": "out_inner_parallel",
       "source": "A",
-      "sourceProperty": "out_inner_parallel"
+      "destination": "output connector",
+      "dataFlow": {
+          "out_outer_parallel": "out_outer_parallel"
+      }
+    },
+    {
+      "source": "input connector",
+      "destination": "A",
+      "dataFlow": {
+          "in_inner_parallel": "in_inner_parallel"
+      }
+    },
+    {
+      "source": "A",
+      "destination": "output connector",
+      "dataFlow": {
+          "out_inner_parallel": "out_inner_parallel"
+      }
     }
   ],
   "tasks": {
@@ -33,28 +37,32 @@
           "parameters": {
             "links": [
               {
-                "destination": "Inner",
-                "destinationProperty": "animal_type_in",
                 "source": "input connector",
-                "sourceProperty": "in_outer_parallel"
-              },
-              {
-                "destination": "output connector",
-                "destinationProperty": "out_outer_parallel",
-                "source": "Inner",
-                "sourceProperty": "animal_type_out"
-              },
-              {
                 "destination": "Inner",
-                "destinationProperty": "kitten_name_in",
-                "source": "input connector",
-                "sourceProperty": "in_inner_parallel"
+                "dataFlow": {
+                    "in_outer_parallel": "animal_type_in"
+                }
               },
               {
-                "destination": "output connector",
-                "destinationProperty": "out_inner_parallel",
                 "source": "Inner",
-                "sourceProperty": "kitten_name_out"
+                "destination": "output connector",
+                "dataFlow": {
+                    "animal_type_out": "out_outer_parallel"
+                }
+              },
+              {
+                "source": "input connector",
+                "destination": "Inner",
+                "dataFlow": {
+                    "in_inner_parallel": "kitten_name_in"
+                }
+              },
+              {
+                "source": "Inner",
+                "destination": "output connector",
+                "dataFlow": {
+                    "kitten_name_out": "out_inner_parallel"
+                }
               }
             ],
             "tasks": {
@@ -65,28 +73,32 @@
                     "parameters": {
                       "links": [
                         {
-                          "destination": "A",
-                          "destinationProperty": "animal_type",
                           "source": "input connector",
-                          "sourceProperty": "animal_type_in"
-                        },
-                        {
-                          "destination": "output connector",
-                          "destinationProperty": "animal_type_out",
-                          "source": "A",
-                          "sourceProperty": "animal_type"
-                        },
-                        {
                           "destination": "A",
-                          "destinationProperty": "kitten_name",
-                          "source": "input connector",
-                          "sourceProperty": "kitten_name_in"
+                          "dataFlow": {
+                              "animal_type_in": "animal_type"
+                          }
                         },
                         {
-                          "destination": "output connector",
-                          "destinationProperty": "kitten_name_out",
                           "source": "A",
-                          "sourceProperty": "kitten_name"
+                          "destination": "output connector",
+                          "dataFlow": {
+                              "animal_type": "animal_type_out"
+                          }
+                        },
+                        {
+                          "source": "input connector",
+                          "destination": "A",
+                          "dataFlow": {
+                              "kitten_name_in": "kitten_name"
+                          }
+                        },
+                        {
+                          "source": "A",
+                          "destination": "output connector",
+                          "dataFlow": {
+                              "kitten_name": "kitten_name_out"
+                          }
                         }
                       ],
                       "tasks": {

--- a/tests/api/v1/system_tests/nested_parallel_by_operation_matrix_fail/submit.json
+++ b/tests/api/v1/system_tests/nested_parallel_by_operation_matrix_fail/submit.json
@@ -1,16 +1,18 @@
 {
   "links": [
     {
-      "destination": "A",
-      "destinationProperty": "in_matrix",
       "source": "input connector",
-      "sourceProperty": "in_matrix"
+      "destination": "A",
+      "dataFlow": {
+          "in_matrix": "in_matrix"
+      }
     },
     {
-      "destination": "output connector",
-      "destinationProperty": "out_matrix",
       "source": "A",
-      "sourceProperty": "out_matrix"
+      "destination": "output connector",
+      "dataFlow": {
+          "out_matrix": "out_matrix"
+      }
     }
   ],
   "tasks": {
@@ -21,16 +23,18 @@
           "parameters": {
             "links": [
               {
-                "destination": "A",
-                "destinationProperty": "name",
                 "source": "input connector",
-                "sourceProperty": "in_matrix"
+                "destination": "A",
+                "dataFlow": {
+                    "in_matrix": "name"
+                }
               },
               {
-                "destination": "output connector",
-                "destinationProperty": "out_matrix",
                 "source": "A",
-                "sourceProperty": "name"
+                "destination": "output connector",
+                "dataFlow": {
+                    "name": "out_matrix"
+                }
               }
             ],
             "tasks": {

--- a/tests/api/v1/system_tests/nested_parallel_by_operation_matrix_fail/workflow_details.json
+++ b/tests/api/v1/system_tests/nested_parallel_by_operation_matrix_fail/workflow_details.json
@@ -1,16 +1,18 @@
 {
   "links": [
     {
-      "destination": "A",
-      "destinationProperty": "in_matrix",
       "source": "input connector",
-      "sourceProperty": "in_matrix"
+      "destination": "A",
+      "dataFlow": {
+          "in_matrix": "in_matrix"
+      }
     },
     {
-      "destination": "output connector",
-      "destinationProperty": "out_matrix",
       "source": "A",
-      "sourceProperty": "out_matrix"
+      "destination": "output connector",
+      "dataFlow": {
+          "out_matrix": "out_matrix"
+      }
     }
   ],
   "tasks": {
@@ -21,16 +23,18 @@
           "parameters": {
             "links": [
               {
-                "destination": "A",
-                "destinationProperty": "name",
                 "source": "input connector",
-                "sourceProperty": "in_matrix"
+                "destination": "A",
+                "dataFlow": {
+                    "in_matrix": "name"
+                }
               },
               {
-                "destination": "output connector",
-                "destinationProperty": "out_matrix",
                 "source": "A",
-                "sourceProperty": "name"
+                "destination": "output connector",
+                "dataFlow": {
+                    "name": "out_matrix"
+                }
               }
             ],
             "tasks": {

--- a/tests/api/v1/system_tests/nested_parallel_by_operation_matrix_inputs/submit.json
+++ b/tests/api/v1/system_tests/nested_parallel_by_operation_matrix_inputs/submit.json
@@ -1,16 +1,18 @@
 {
   "links": [
     {
-      "destination": "A",
-      "destinationProperty": "in_matrix",
       "source": "input connector",
-      "sourceProperty": "in_matrix"
+      "destination": "A",
+      "dataFlow": {
+        "in_matrix": "in_matrix"
+      }
     },
     {
-      "destination": "output connector",
-      "destinationProperty": "out_matrix",
       "source": "A",
-      "sourceProperty": "out_matrix"
+      "destination": "output connector",
+      "dataFlow": {
+        "out_matrix": "out_matrix"
+      }
     }
   ],
   "tasks": {
@@ -21,16 +23,18 @@
           "parameters": {
             "links": [
               {
-                "destination": "A",
-                "destinationProperty": "name",
                 "source": "input connector",
-                "sourceProperty": "in_matrix"
+                "destination": "A",
+                "dataFlow": {
+                  "in_matrix": "name"
+                }
               },
               {
-                "destination": "output connector",
-                "destinationProperty": "out_matrix",
                 "source": "A",
-                "sourceProperty": "name"
+                "destination": "output connector",
+                "dataFlow": {
+                  "name": "out_matrix"
+                }
               }
             ],
             "tasks": {

--- a/tests/api/v1/system_tests/nested_parallel_by_operation_minimal/submit.json
+++ b/tests/api/v1/system_tests/nested_parallel_by_operation_minimal/submit.json
@@ -1,16 +1,18 @@
 {
   "links": [
     {
-      "destination": "A",
-      "destinationProperty": "in_matrix",
       "source": "input connector",
-      "sourceProperty": "in_matrix"
+      "destination": "A",
+      "dataFlow": {
+        "in_matrix": "in_matrix"
+      }
     },
     {
-      "destination": "output connector",
-      "destinationProperty": "out_matrix",
       "source": "A",
-      "sourceProperty": "out_matrix"
+      "destination": "output connector",
+      "dataFlow": {
+        "out_matrix": "out_matrix"
+      }
     }
   ],
   "tasks": {
@@ -21,10 +23,11 @@
           "parameters": {
             "links": [
               {
-                "destination": "output connector",
-                "destinationProperty": "out_matrix",
                 "source": "input connector",
-                "sourceProperty": "in_matrix"
+                "destination": "output connector",
+                "dataFlow": {
+                  "in_matrix": "out_matrix"
+                }
               }
             ],
             "tasks": { }

--- a/tests/api/v1/system_tests/nested_parallel_by_operation_orthogonal_inputs/submit.json
+++ b/tests/api/v1/system_tests/nested_parallel_by_operation_orthogonal_inputs/submit.json
@@ -4,6 +4,7 @@
       "source": "input connector",
       "destination": "A",
       "dataFlow": {
+        "in_inner_parallel": "in_inner_parallel",
         "in_outer_parallel": "in_outer_parallel"
       }
     },
@@ -11,21 +12,8 @@
       "source": "A",
       "destination": "output connector",
       "dataFlow": {
+        "out_inner_parallel": "out_inner_parallel",
         "out_outer_parallel": "out_outer_parallel"
-      }
-    },
-    {
-      "source": "input connector",
-      "destination": "A",
-      "dataFlow": {
-        "in_inner_parallel": "in_inner_parallel"
-      }
-    },
-    {
-      "source": "A",
-      "destination": "output connector",
-      "dataFlow": {
-        "out_inner_parallel": "out_inner_parallel"
       }
     }
   ],
@@ -40,6 +28,7 @@
                 "source": "input connector",
                 "destination": "A",
                 "dataFlow": {
+                  "in_inner_parallel": "kitten_name",
                   "in_outer_parallel": "animal_type"
                 }
               },
@@ -47,20 +36,7 @@
                 "source": "A",
                 "destination": "output connector",
                 "dataFlow": {
-                  "animal_type": "out_outer_parallel"
-                }
-              },
-              {
-                "source": "input connector",
-                "destination": "A",
-                "dataFlow": {
-                  "in_inner_parallel": "kitten_name"
-                }
-              },
-              {
-                "source": "A",
-                "destination": "output connector",
-                "dataFlow": {
+                  "animal_type": "out_outer_parallel",
                   "kitten_name": "out_inner_parallel"
                 }
               }

--- a/tests/api/v1/system_tests/nested_parallel_by_operation_orthogonal_inputs/submit.json
+++ b/tests/api/v1/system_tests/nested_parallel_by_operation_orthogonal_inputs/submit.json
@@ -1,28 +1,32 @@
 {
   "links": [
     {
-      "destination": "A",
-      "destinationProperty": "in_outer_parallel",
       "source": "input connector",
-      "sourceProperty": "in_outer_parallel"
-    },
-    {
-      "destination": "output connector",
-      "destinationProperty": "out_outer_parallel",
-      "source": "A",
-      "sourceProperty": "out_outer_parallel"
-    },
-    {
       "destination": "A",
-      "destinationProperty": "in_inner_parallel",
-      "source": "input connector",
-      "sourceProperty": "in_inner_parallel"
+      "dataFlow": {
+        "in_outer_parallel": "in_outer_parallel"
+      }
     },
     {
-      "destination": "output connector",
-      "destinationProperty": "out_inner_parallel",
       "source": "A",
-      "sourceProperty": "out_inner_parallel"
+      "destination": "output connector",
+      "dataFlow": {
+        "out_outer_parallel": "out_outer_parallel"
+      }
+    },
+    {
+      "source": "input connector",
+      "destination": "A",
+      "dataFlow": {
+        "in_inner_parallel": "in_inner_parallel"
+      }
+    },
+    {
+      "source": "A",
+      "destination": "output connector",
+      "dataFlow": {
+        "out_inner_parallel": "out_inner_parallel"
+      }
     }
   ],
   "tasks": {
@@ -33,28 +37,32 @@
           "parameters": {
             "links": [
               {
-                "destination": "A",
-                "destinationProperty": "animal_type",
                 "source": "input connector",
-                "sourceProperty": "in_outer_parallel"
-              },
-              {
-                "destination": "output connector",
-                "destinationProperty": "out_outer_parallel",
-                "source": "A",
-                "sourceProperty": "animal_type"
-              },
-              {
                 "destination": "A",
-                "destinationProperty": "kitten_name",
-                "source": "input connector",
-                "sourceProperty": "in_inner_parallel"
+                "dataFlow": {
+                  "in_outer_parallel": "animal_type"
+                }
               },
               {
-                "destination": "output connector",
-                "destinationProperty": "out_inner_parallel",
                 "source": "A",
-                "sourceProperty": "kitten_name"
+                "destination": "output connector",
+                "dataFlow": {
+                  "animal_type": "out_outer_parallel"
+                }
+              },
+              {
+                "source": "input connector",
+                "destination": "A",
+                "dataFlow": {
+                  "in_inner_parallel": "kitten_name"
+                }
+              },
+              {
+                "source": "A",
+                "destination": "output connector",
+                "dataFlow": {
+                  "kitten_name": "out_inner_parallel"
+                }
               }
             ],
             "tasks": {

--- a/tests/api/v1/system_tests/output_neglecting_command/submit.json
+++ b/tests/api/v1/system_tests/output_neglecting_command/submit.json
@@ -20,26 +20,18 @@
         {
             "source": "input connector",
             "destination": "A",
-            "sourceProperty": "in_a",
-            "destinationProperty": "param_a"
+            "dataFlow": {
+                "in_a": "param_a",
+                "in_b": "param_b"
+            }
         },
         {
             "source": "A",
             "destination": "output connector",
-            "sourceProperty": "param_a",
-            "destinationProperty": "out_a"
-        },
-        {
-            "source": "input connector",
-            "destination": "A",
-            "sourceProperty": "in_b",
-            "destinationProperty": "param_b"
-        },
-        {
-            "source": "A",
-            "destination": "output connector",
-            "sourceProperty": "param_b",
-            "destinationProperty": "out_b"
+            "dataFlow": {
+                "param_a": "out_a",
+                "param_b": "out_b"
+            }
         }
     ],
 

--- a/tests/api/v1/system_tests/parallel_by_dag/submit.json
+++ b/tests/api/v1/system_tests/parallel_by_dag/submit.json
@@ -1,28 +1,20 @@
 {
   "links": [
     {
-      "destination": "A",
-      "destinationProperty": "in_constant",
       "source": "input connector",
-      "sourceProperty": "in_constant"
-    },
-    {
-      "destination": "output connector",
-      "destinationProperty": "out_constant",
-      "source": "A",
-      "sourceProperty": "out_constant"
-    },
-    {
       "destination": "A",
-      "destinationProperty": "in_parallel",
-      "source": "input connector",
-      "sourceProperty": "in_parallel"
+      "dataFlow": {
+         "in_constant": "in_constant",
+         "in_parallel": "in_parallel"
+      }
     },
     {
-      "destination": "output connector",
-      "destinationProperty": "out_parallel",
       "source": "A",
-      "sourceProperty": "out_parallel"
+      "destination": "output connector",
+      "dataFlow": {
+         "out_parallel": "out_parallel",
+         "out_constant": "out_constant"
+      }
     }
   ],
   "tasks": {
@@ -33,28 +25,20 @@
           "parameters": {
             "links": [
               {
-                "destination": "A",
-                "destinationProperty": "const_param",
                 "source": "input connector",
-                "sourceProperty": "in_constant"
-              },
-              {
-                "destination": "output connector",
-                "destinationProperty": "out_constant",
-                "source": "A",
-                "sourceProperty": "const_param"
-              },
-              {
                 "destination": "A",
-                "destinationProperty": "parallel_param",
-                "source": "input connector",
-                "sourceProperty": "in_parallel"
+                "dataFlow": {
+                    "in_constant": "const_param",
+                    "in_parallel": "parallel_param"
+                }
               },
               {
-                "destination": "output connector",
-                "destinationProperty": "out_parallel",
                 "source": "A",
-                "sourceProperty": "parallel_param"
+                "destination": "output connector",
+                "dataFlow": {
+                    "const_param": "out_constant",
+                    "parallel_param": "out_parallel"
+                }
               }
             ],
             "tasks": {

--- a/tests/api/v1/system_tests/parallel_by_dag_pass_through/submit.json
+++ b/tests/api/v1/system_tests/parallel_by_dag_pass_through/submit.json
@@ -24,27 +24,31 @@
                         "links": [
                             {
                                 "source": "input connector",
-                                "sourceProperty": "constant_param_in",
                                 "destination": "output connector",
-                                "destinationProperty": "constant_param_out"
+                                "dataFlow": {
+                                    "constant_param_in": "constant_param_out"
+                                }
                             },
                             {
                                 "source": "input connector",
-                                "sourceProperty": "constant_param_in",
                                 "destination": "michael",
-                                "destinationProperty": "constant_param_in"
+                                "dataFlow": {
+                                    "constant_param_in": "constant_param_in"
+                                }
                             },
                             {
                                 "source": "input connector",
-                                "sourceProperty": "parallel_param_in",
                                 "destination": "output connector",
-                                "destinationProperty": "parallel_param_out"
+                                "dataFlow": {
+                                    "parallel_param_in": "parallel_param_out"
+                                }
                             },
                             {
                                 "source": "michael",
-                                "sourceProperty": "constant_param_in",
                                 "destination": "output connector",
-                                "destinationProperty": "michael_param_out"
+                                "dataFlow": {
+                                    "constant_param_in": "michael_param_out"
+                                }
                             }
                         ]
                     },
@@ -73,39 +77,26 @@
         {
             "source": "input connector",
             "destination": "Inner",
-            "sourceProperty": "in_constant",
-            "destinationProperty": "constant_param_in"
+            "dataFlow": {
+                "in_constant": "constant_param_in",
+                "in_parallel": "parallel_param_in"
+            }
         },
         {
             "source": "Inner",
             "destination": "A",
-            "sourceProperty": "constant_param_out",
-            "destinationProperty": "constant_param"
+            "dataFlow": {
+                "constant_param_out": "constant_param",
+                "parallel_param_out": "parallel_param"
+            }
         },
         {
             "source": "A",
             "destination": "output connector",
-            "sourceProperty": "constant_param",
-            "destinationProperty": "out_constant"
-        },
-
-        {
-            "source": "input connector",
-            "destination": "Inner",
-            "sourceProperty": "in_parallel",
-            "destinationProperty": "parallel_param_in"
-        },
-        {
-            "source": "Inner",
-            "destination": "A",
-            "sourceProperty": "parallel_param_out",
-            "destinationProperty": "parallel_param"
-        },
-        {
-            "source": "A",
-            "destination": "output connector",
-            "sourceProperty": "parallel_param",
-            "destinationProperty": "out_parallel"
+            "dataFlow": {
+                "constant_param": "out_constant",
+                "parallel_param": "out_parallel"
+            }
         }
     ],
 

--- a/tests/api/v1/system_tests/parallel_by_dag_pass_through/submit.json
+++ b/tests/api/v1/system_tests/parallel_by_dag_pass_through/submit.json
@@ -26,7 +26,8 @@
                                 "source": "input connector",
                                 "destination": "output connector",
                                 "dataFlow": {
-                                    "constant_param_in": "constant_param_out"
+                                    "constant_param_in": "constant_param_out",
+                                    "parallel_param_in": "parallel_param_out"
                                 }
                             },
                             {
@@ -34,13 +35,6 @@
                                 "destination": "michael",
                                 "dataFlow": {
                                     "constant_param_in": "constant_param_in"
-                                }
-                            },
-                            {
-                                "source": "input connector",
-                                "destination": "output connector",
-                                "dataFlow": {
-                                    "parallel_param_in": "parallel_param_out"
                                 }
                             },
                             {

--- a/tests/api/v1/system_tests/parallel_by_nested_dag/submit.json
+++ b/tests/api/v1/system_tests/parallel_by_nested_dag/submit.json
@@ -27,21 +27,7 @@
                                 "source": "input connector",
                                 "destination": "A",
                                 "dataFlow": {
-                                    "constant_param_in": "constant_param"
-                                }
-                            },
-                            {
-                                "source": "A",
-                                "destination": "output connector",
-                                "dataFlow": {
-                                    "constant_param": "constant_param_out"
-                                }
-                            },
-
-                            {
-                                "source": "input connector",
-                                "destination": "A",
-                                "dataFlow": {
+                                    "constant_param_in": "constant_param",
                                     "parallel_param_in": "parallel_param"
                                 }
                             },
@@ -49,6 +35,7 @@
                                 "source": "A",
                                 "destination": "output connector",
                                 "dataFlow": {
+                                    "constant_param": "constant_param_out",
                                     "parallel_param": "parallel_param_out"
                                 }
                             }
@@ -66,21 +53,7 @@
             "source": "input connector",
             "destination": "Inner",
             "dataFlow": {
-                "in_constant": "constant_param_in"
-            }
-        },
-        {
-            "source": "Inner",
-            "destination": "output connector",
-            "dataFlow": {
-                "constant_param_out": "out_constant"
-            }
-        },
-
-        {
-            "source": "input connector",
-            "destination": "Inner",
-            "dataFlow": {
+                "in_constant": "constant_param_in",
                 "in_parallel": "parallel_param_in"
             }
         },
@@ -88,6 +61,7 @@
             "source": "Inner",
             "destination": "output connector",
             "dataFlow": {
+                "constant_param_out": "out_constant",
                 "parallel_param_out": "out_parallel"
             }
         }

--- a/tests/api/v1/system_tests/parallel_by_nested_dag/submit.json
+++ b/tests/api/v1/system_tests/parallel_by_nested_dag/submit.json
@@ -26,27 +26,31 @@
                             {
                                 "source": "input connector",
                                 "destination": "A",
-                                "sourceProperty": "constant_param_in",
-                                "destinationProperty": "constant_param"
+                                "dataFlow": {
+                                    "constant_param_in": "constant_param"
+                                }
                             },
                             {
                                 "source": "A",
                                 "destination": "output connector",
-                                "sourceProperty": "constant_param",
-                                "destinationProperty": "constant_param_out"
+                                "dataFlow": {
+                                    "constant_param": "constant_param_out"
+                                }
                             },
 
                             {
                                 "source": "input connector",
                                 "destination": "A",
-                                "sourceProperty": "parallel_param_in",
-                                "destinationProperty": "parallel_param"
+                                "dataFlow": {
+                                    "parallel_param_in": "parallel_param"
+                                }
                             },
                             {
                                 "source": "A",
                                 "destination": "output connector",
-                                "sourceProperty": "parallel_param",
-                                "destinationProperty": "parallel_param_out"
+                                "dataFlow": {
+                                    "parallel_param": "parallel_param_out"
+                                }
                             }
                         ]
                     },
@@ -61,27 +65,31 @@
         {
             "source": "input connector",
             "destination": "Inner",
-            "sourceProperty": "in_constant",
-            "destinationProperty": "constant_param_in"
+            "dataFlow": {
+                "in_constant": "constant_param_in"
+            }
         },
         {
             "source": "Inner",
             "destination": "output connector",
-            "sourceProperty": "constant_param_out",
-            "destinationProperty": "out_constant"
+            "dataFlow": {
+                "constant_param_out": "out_constant"
+            }
         },
 
         {
             "source": "input connector",
             "destination": "Inner",
-            "sourceProperty": "in_parallel",
-            "destinationProperty": "parallel_param_in"
+            "dataFlow": {
+                "in_parallel": "parallel_param_in"
+            }
         },
         {
             "source": "Inner",
             "destination": "output connector",
-            "sourceProperty": "parallel_param_out",
-            "destinationProperty": "out_parallel"
+            "dataFlow": {
+                "parallel_param_out": "out_parallel"
+            }
         }
     ],
 

--- a/tests/api/v1/system_tests/parallel_by_operation/submit.json
+++ b/tests/api/v1/system_tests/parallel_by_operation/submit.json
@@ -21,27 +21,18 @@
         {
             "source": "input connector",
             "destination": "A",
-            "sourceProperty": "in_constant",
-            "destinationProperty": "constant_param"
+            "dataFlow": {
+                "in_constant": "constant_param",
+                "in_parallel": "parallel_param"
+            }
         },
         {
             "source": "A",
             "destination": "output connector",
-            "sourceProperty": "constant_param",
-            "destinationProperty": "out_constant"
-        },
-
-        {
-            "source": "input connector",
-            "destination": "A",
-            "sourceProperty": "in_parallel",
-            "destinationProperty": "parallel_param"
-        },
-        {
-            "source": "A",
-            "destination": "output connector",
-            "sourceProperty": "parallel_param",
-            "destinationProperty": "out_parallel"
+            "dataFlow": {
+                "constant_param": "out_constant",
+                "parallel_param": "out_parallel"
+            }
         }
     ],
 

--- a/tests/api/v1/system_tests/parallel_by_scalar_input/submit.json
+++ b/tests/api/v1/system_tests/parallel_by_scalar_input/submit.json
@@ -21,27 +21,18 @@
         {
             "source": "input connector",
             "destination": "A",
-            "sourceProperty": "in_constant",
-            "destinationProperty": "constant_param"
+            "dataFlow": {
+                "in_constant": "constant_param",
+                "in_parallel": "parallel_param"
+            }
         },
         {
             "source": "A",
             "destination": "output connector",
-            "sourceProperty": "constant_param",
-            "destinationProperty": "out_constant"
-        },
-
-        {
-            "source": "input connector",
-            "destination": "A",
-            "sourceProperty": "in_parallel",
-            "destinationProperty": "parallel_param"
-        },
-        {
-            "source": "A",
-            "destination": "output connector",
-            "sourceProperty": "parallel_param",
-            "destinationProperty": "out_parallel"
+            "dataFlow": {
+                "constant_param": "out_constant",
+                "parallel_param": "out_parallel"
+            }
         }
     ],
 

--- a/tests/api/v1/system_tests/parallel_by_scalar_input/workflow_details.json
+++ b/tests/api/v1/system_tests/parallel_by_scalar_input/workflow_details.json
@@ -24,27 +24,18 @@
         {
             "source": "input connector",
             "destination": "A",
-            "sourceProperty": "in_constant",
-            "destinationProperty": "constant_param"
+            "dataFlow": {
+                "in_constant": "constant_param",
+                "in_parallel": "parallel_param"
+            }
         },
         {
             "source": "A",
             "destination": "output connector",
-            "sourceProperty": "constant_param",
-            "destinationProperty": "out_constant"
-        },
-
-        {
-            "source": "input connector",
-            "destination": "A",
-            "sourceProperty": "in_parallel",
-            "destinationProperty": "parallel_param"
-        },
-        {
-            "source": "A",
-            "destination": "output connector",
-            "sourceProperty": "parallel_param",
-            "destinationProperty": "out_parallel"
+            "dataFlow": {
+                "constant_param": "out_constant",
+                "parallel_param": "out_parallel"
+            }
         }
     ],
 

--- a/tests/api/v1/system_tests/sequential_parallel_by/submit.json
+++ b/tests/api/v1/system_tests/sequential_parallel_by/submit.json
@@ -36,39 +36,26 @@
         {
             "source": "input connector",
             "destination": "A",
-            "sourceProperty": "in_constant",
-            "destinationProperty": "constant_param"
+            "dataFlow": {
+                "in_constant": "constant_param",
+                "in_parallel": "parallel_param"
+            }
         },
         {
             "source": "A",
             "destination": "B",
-            "sourceProperty": "constant_param",
-            "destinationProperty": "constant_param"
+            "dataFlow": {
+                "constant_param": "constant_param",
+                "parallel_param": "parallel_param"
+            }
         },
         {
             "source": "B",
             "destination": "output connector",
-            "sourceProperty": "constant_param",
-            "destinationProperty": "out_constant"
-        },
-
-        {
-            "source": "input connector",
-            "destination": "A",
-            "sourceProperty": "in_parallel",
-            "destinationProperty": "parallel_param"
-        },
-        {
-            "source": "A",
-            "destination": "B",
-            "sourceProperty": "parallel_param",
-            "destinationProperty": "parallel_param"
-        },
-        {
-            "source": "B",
-            "destination": "output connector",
-            "sourceProperty": "parallel_param",
-            "destinationProperty": "out_parallel"
+            "dataFlow": {
+                "constant_param": "out_constant",
+                "parallel_param": "out_parallel"
+            }
         }
     ],
 

--- a/tests/api/v1/system_tests/serial/submit.json
+++ b/tests/api/v1/system_tests/serial/submit.json
@@ -48,26 +48,30 @@
         {
             "source": "input connector",
             "destination": "A",
-            "sourceProperty": "in_val",
-            "destinationProperty": "param"
+            "dataFlow": {
+                "in_val": "param"
+            }
         },
         {
             "source": "A",
             "destination": "B",
-            "sourceProperty": "param",
-            "destinationProperty": "param"
+            "dataFlow": {
+                "param": "param"
+            }
         },
         {
             "source": "B",
             "destination": "C",
-            "sourceProperty": "param",
-            "destinationProperty": "param"
+            "dataFlow": {
+                "param": "param"
+            }
         },
         {
             "source": "C",
             "destination": "output connector",
-            "sourceProperty": "param",
-            "destinationProperty": "out_val"
+            "dataFlow": {
+                "param": "out_val"
+            }
         }
     ],
 

--- a/tests/api/v1/system_tests/shortcut_failure/submit.json
+++ b/tests/api/v1/system_tests/shortcut_failure/submit.json
@@ -30,14 +30,16 @@
         {
             "source": "input connector",
             "destination": "A",
-            "sourceProperty": "in_a",
-            "destinationProperty": "param"
+            "dataFlow": {
+                "in_a": "param"
+            }
         },
         {
             "source": "A",
             "destination": "output connector",
-            "sourceProperty": "param",
-            "destinationProperty": "out_a"
+            "dataFlow": {
+                "param": "out_a"
+            }
         }
     ],
 

--- a/tests/api/v1/system_tests/shortcut_failure/workflow_details.json
+++ b/tests/api/v1/system_tests/shortcut_failure/workflow_details.json
@@ -39,14 +39,16 @@
         {
             "source": "input connector",
             "destination": "A",
-            "sourceProperty": "in_a",
-            "destinationProperty": "param"
+            "dataFlow": {
+                "in_a": "param"
+            }
         },
         {
             "source": "A",
             "destination": "output connector",
-            "sourceProperty": "param",
-            "destinationProperty": "out_a"
+            "dataFlow": {
+                "param": "out_a"
+            }
         }
     ],
 

--- a/tests/api/v1/system_tests/shortcut_success/submit.json
+++ b/tests/api/v1/system_tests/shortcut_success/submit.json
@@ -30,14 +30,16 @@
         {
             "source": "input connector",
             "destination": "A",
-            "sourceProperty": "in_a",
-            "destinationProperty": "param"
+            "dataFlow": {
+                "in_a": "param"
+            }
         },
         {
             "source": "A",
             "destination": "output connector",
-            "sourceProperty": "param",
-            "destinationProperty": "out_a"
+            "dataFlow": {
+                "param": "out_a"
+            }
         }
     ],
 

--- a/tests/api/v1/system_tests/single_cat_operation/result.json
+++ b/tests/api/v1/system_tests/single_cat_operation/result.json
@@ -1,0 +1,5 @@
+{
+    "outputs": {
+        "result": "foofoobar"
+    }
+}

--- a/tests/api/v1/system_tests/single_cat_operation/submit.json
+++ b/tests/api/v1/system_tests/single_cat_operation/submit.json
@@ -1,0 +1,41 @@
+{
+    "tasks": {
+        "A": {
+            "methods": [
+                {
+                    "name": "execute",
+                    "service": "shell-command",
+                    "parameters": {
+                        "commandLine": ["./cat_command"],
+                        "user": "{{ user }}",
+                        "workingDirectory": "{{ workingDirectory }}",
+                        "environment": {{ environment }}
+                    }
+                }
+            ]
+        }
+    },
+
+    "links": [
+        {
+            "source": "input connector",
+            "destination": "A",
+            "dataFlow": {
+                "in_1": ["a", "b"],
+                "in_2": "c"
+            }
+        },
+        {
+            "source": "A",
+            "destination": "output connector",
+            "dataFlow": {
+                "result": "result"
+            }
+        }
+    ],
+
+    "inputs": {
+        "in_1": "foo",
+        "in_2": "bar"
+    }
+}

--- a/tests/api/v1/system_tests/single_cat_operation/workflow_details.json
+++ b/tests/api/v1/system_tests/single_cat_operation/workflow_details.json
@@ -1,0 +1,45 @@
+{
+    "tasks": {
+        "A": {
+            "methods": [
+                {
+                    "name": "execute",
+                    "service": "shell-command",
+                    "parameters": {
+                        "commandLine": ["./echo_command"],
+                        "user": "",
+                        "workingDirectory": "",
+                        "environment": ""
+                    },
+                    "executions": {
+                        "0": { "status": "succeeded" }
+                    }
+                }
+            ],
+            "executions": {
+                "0": { "status": "succeeded" }
+            }
+        }
+    },
+
+    "links": [
+        {
+            "source": "input connector",
+            "destination": "A",
+            "dataFlow": {
+                "in_a": "param"
+            }
+        },
+        {
+            "source": "A",
+            "destination": "output connector",
+            "dataFlow": {
+                "param": "out_a"
+            }
+        }
+    ],
+
+    "inputs": {
+        "in_a": "kittens"
+    }
+}

--- a/tests/api/v1/system_tests/single_cat_operation/workflow_executions.json
+++ b/tests/api/v1/system_tests/single_cat_operation/workflow_executions.json
@@ -1,0 +1,187 @@
+{
+    "executions": [
+        {
+            "begins": [], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/406", 
+            "id": 406, 
+            "parentColor": null, 
+            "status": "succeeded", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-05-27 21:56:51.767792+00:00"
+                }, 
+                {
+                    "status": "succeeded", 
+                    "timestamp": "2015-05-27 21:56:53.748215+00:00"
+                }
+            ], 
+            "taskId": 250
+        }, 
+        {
+            "begins": [
+                0
+            ], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/407", 
+            "id": 407, 
+            "methodId": 93, 
+            "parentColor": null, 
+            "status": "succeeded", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-05-27 21:56:52.262896+00:00"
+                }, 
+                {
+                    "status": "scheduled", 
+                    "timestamp": "2015-05-27 21:56:52.431861+00:00"
+                }, 
+                {
+                    "status": "running", 
+                    "timestamp": "2015-05-27 21:56:52.431861+00:00"
+                }, 
+                {
+                    "status": "succeeded", 
+                    "timestamp": "2015-05-27 21:56:53.715603+00:00"
+                }
+            ]
+        }, 
+        {
+            "begins": [
+                0
+            ], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/408", 
+            "id": 408, 
+            "parentColor": null, 
+            "status": "succeeded", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-05-27 21:56:52.343559+00:00"
+                }, 
+                {
+                    "status": "scheduled", 
+                    "timestamp": "2015-05-27 21:56:52.343559+00:00"
+                }, 
+                {
+                    "status": "running", 
+                    "timestamp": "2015-05-27 21:56:52.343559+00:00"
+                }, 
+                {
+                    "status": "succeeded", 
+                    "timestamp": "2015-05-27 21:56:52.510753+00:00"
+                }
+            ], 
+            "taskId": 252
+        }, 
+        {
+            "begins": [
+                0
+            ], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/409", 
+            "id": 409, 
+            "parentColor": null, 
+            "status": "succeeded", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-05-27 21:56:52.579110+00:00"
+                }, 
+                {
+                    "status": "scheduled", 
+                    "timestamp": "2015-05-27 21:56:52.579110+00:00"
+                }, 
+                {
+                    "status": "running", 
+                    "timestamp": "2015-05-27 21:56:52.579110+00:00"
+                }, 
+                {
+                    "status": "succeeded", 
+                    "timestamp": "2015-05-27 21:56:53.449905+00:00"
+                }
+            ], 
+            "taskId": 254
+        }, 
+        {
+            "begins": [
+                0
+            ], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/410", 
+            "id": 410, 
+            "methodId": 94, 
+            "parentColor": null, 
+            "status": "succeeded", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-05-27 21:56:52.660114+00:00"
+                }, 
+                {
+                    "status": "scheduled", 
+                    "timestamp": "2015-05-27 21:56:52.736024+00:00"
+                }, 
+                {
+                    "status": "running", 
+                    "timestamp": "2015-05-27 21:56:53.259154+00:00"
+                }, 
+                {
+                    "status": "succeeded", 
+                    "timestamp": "2015-05-27 21:56:53.375273+00:00"
+                }
+            ]
+        }, 
+        {
+            "begins": [
+                0
+            ], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/411", 
+            "id": 411, 
+            "parentColor": null, 
+            "status": "succeeded", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-05-27 21:56:53.505844+00:00"
+                }, 
+                {
+                    "status": "scheduled", 
+                    "timestamp": "2015-05-27 21:56:53.505844+00:00"
+                }, 
+                {
+                    "status": "running", 
+                    "timestamp": "2015-05-27 21:56:53.505844+00:00"
+                }, 
+                {
+                    "status": "succeeded", 
+                    "timestamp": "2015-05-27 21:56:53.663093+00:00"
+                }
+            ], 
+            "taskId": 253
+        }
+    ], 
+    "updateUrl": "http://localhost:7000/v1/reports/workflow-executions?since=2015-05-27+21%3A56%3A53.748215&workflow_id=35"
+}

--- a/tests/api/v1/system_tests/single_cat_operation/workflow_skeleton.json
+++ b/tests/api/v1/system_tests/single_cat_operation/workflow_skeleton.json
@@ -1,0 +1,19 @@
+{
+    "id": 35, 
+    "name": "0LSxQUSSQjqwTky0_LI_dA", 
+    "rootTaskId": 250, 
+    "status": "succeeded", 
+    "tasks": {
+        "A": {
+            "id": 253, 
+            "methods": [
+                {
+                    "id": 94, 
+                    "name": "execute", 
+                    "service": "shell-command"
+                }
+            ], 
+            "topologicalIndex": 0
+        }
+    }
+}

--- a/tests/api/v1/system_tests/single_operation/submit.json
+++ b/tests/api/v1/system_tests/single_operation/submit.json
@@ -20,14 +20,16 @@
         {
             "source": "input connector",
             "destination": "A",
-            "sourceProperty": "in_a",
-            "destinationProperty": "param"
+            "dataFlow": {
+                "in_a": "param"
+            }
         },
         {
             "source": "A",
             "destination": "output connector",
-            "sourceProperty": "param",
-            "destinationProperty": "out_a"
+            "dataFlow": {
+                "param": "out_a"
+            }
         }
     ],
 

--- a/tests/api/v1/system_tests/single_operation/workflow_details.json
+++ b/tests/api/v1/system_tests/single_operation/workflow_details.json
@@ -26,14 +26,16 @@
         {
             "source": "input connector",
             "destination": "A",
-            "sourceProperty": "in_a",
-            "destinationProperty": "param"
+            "dataFlow": {
+                "in_a": "param"
+            }
         },
         {
             "source": "A",
             "destination": "output connector",
-            "sourceProperty": "param",
-            "destinationProperty": "out_a"
+            "dataFlow": {
+                "param": "out_a"
+            }
         }
     ],
 

--- a/tests/api/v1/system_tests/single_operation_update_command/submit.json
+++ b/tests/api/v1/system_tests/single_operation_update_command/submit.json
@@ -20,14 +20,16 @@
         {
             "source": "input connector",
             "destination": "A",
-            "sourceProperty": "in_a",
-            "destinationProperty": "param"
+            "dataFlow": {
+                "in_a": "param"
+            }
         },
         {
             "source": "A",
             "destination": "output connector",
-            "sourceProperty": "param",
-            "destinationProperty": "out_a"
+            "dataFlow": {
+                "param": "out_a"
+            }
         }
     ],
 

--- a/tests/api/v1/system_tests/split_outputs/submit.json
+++ b/tests/api/v1/system_tests/split_outputs/submit.json
@@ -48,38 +48,38 @@
         {
             "source": "input connector",
             "destination": "A",
-            "sourceProperty": "in_1",
-            "destinationProperty": "param_1"
-        },
-        {
-            "source": "input connector",
-            "destination": "A",
-            "sourceProperty": "in_2",
-            "destinationProperty": "param_2"
+            "dataFlow": {
+                "in_1": "param_1",
+                "in_2": "param_2"
+            }
         },
         {
             "source": "A",
             "destination": "B",
-            "sourceProperty": "param_1",
-            "destinationProperty": "param"
+            "dataFlow": {
+                "param_1": "param"
+            }
         },
         {
             "source": "A",
             "destination": "C",
-            "sourceProperty": "param_2",
-            "destinationProperty": "param"
+            "dataFlow": {
+                "param_2": "param"
+            }
         },
         {
             "source": "B",
             "destination": "output connector",
-            "sourceProperty": "param",
-            "destinationProperty": "out_1"
+            "dataFlow": {
+                "param": "out_1"
+            }
         },
         {
             "source": "C",
             "destination": "output connector",
-            "sourceProperty": "param",
-            "destinationProperty": "out_2"
+            "dataFlow": {
+                "param": "out_2"
+            }
         }
     ],
 

--- a/tests/api/v1/test_cancel_workflow.py
+++ b/tests/api/v1/test_cancel_workflow.py
@@ -29,14 +29,16 @@ class TestCancelWorkflow(BaseAPITest):
                     {
                         'source': 'input connector',
                         'destination': 'A',
-                        'sourceProperty': 'in_a',
-                        'destinationProperty': 'param',
+                        'dataFlow': {
+                            'in_a': 'param'
+                            }
                         },
                     {
                         'source': 'A',
                         'destination': 'output connector',
-                        'sourceProperty': 'result',
-                        'destinationProperty': 'out_a',
+                        'dataFlow': {
+                            'result': 'out_a'
+                            }
                         },
                     ],
                 'inputs': {

--- a/tests/api/v1/test_post_duplicate_workflow_failure.py
+++ b/tests/api/v1/test_post_duplicate_workflow_failure.py
@@ -39,8 +39,9 @@ class NameFailure(PostDuplicateWorkflowFailure, BaseAPITest):
             {
                 'source': 'input connector',
                 'destination': 'output connector',
-                'sourceProperty': 'in_a',
-                'destinationProperty': 'out_a',
+                'dataFlow': {
+                    'in_a': 'out_a'
+                }
             },
         ],
         'inputs': {

--- a/tests/api/v1/test_post_gzipped_workflow.py
+++ b/tests/api/v1/test_post_gzipped_workflow.py
@@ -26,14 +26,16 @@ class TestGzippedWorkflow(BaseAPITest):
                     {
                         'source': 'input connector',
                         'destination': 'A',
-                        'sourceProperty': 'in_a',
-                        'destinationProperty': 'param',
+                        'dataFlow': {
+                            'in_a': 'param',
+                            },
                         },
                     {
                         'source': 'A',
                         'destination': 'output connector',
-                        'sourceProperty': 'result',
-                        'destinationProperty': 'out_a',
+                        'dataFlow': {
+                            'result': 'out_a',
+                            },
                         },
                     ],
                 'inputs': {

--- a/tests/api/v1/test_post_workflow_failure.py
+++ b/tests/api/v1/test_post_workflow_failure.py
@@ -52,13 +52,15 @@ class BorkIsInvalidWebhookName(PostWorkflowFailure, BaseAPITest):
             {
                 'source': 'input connector',
                 'destination': 'A',
-                'sourceProperty': 'in_a',
-                'destinationProperty': 'param',
+                'dataFlow': {
+                    'in_a': 'param'
+                    }
             }, {
                 'source': 'A',
                 'destination': 'output connector',
-                'sourceProperty': 'result',
-                'destinationProperty': 'out_a',
+                'dataFlow': {
+                    'result': 'out_a'
+                    }
             },
         ],
         'inputs': {
@@ -105,13 +107,15 @@ class InputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
             {
                 'source': 'input connector',
                 'destination': 'A',
-                'sourceProperty': 'in_a',
-                'destinationProperty': 'param',
+                'dataFlow': {
+                    'in_a': 'param'
+                    }
             }, {
                 'source': 'A',
                 'destination': 'output connector',
-                'sourceProperty': 'result',
-                'destinationProperty': 'out_a',
+                'dataFlow': {
+                    'result': 'out_a'
+                    }
             },
         ],
         'inputs': {
@@ -155,13 +159,15 @@ class OutputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
             {
                 'source': 'input connector',
                 'destination': 'A',
-                'sourceProperty': 'in_a',
-                'destinationProperty': 'param',
+                'dataFlow': {
+                    'in_a': 'param'
+                    }
             }, {
                 'source': 'A',
                 'destination': 'output connector',
-                'sourceProperty': 'result',
-                'destinationProperty': 'out_a',
+                'dataFlow': {
+                    'result': 'out_a'
+                    }
             },
         ],
         'inputs': {
@@ -210,13 +216,15 @@ class NestedInputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
                                 {
                                     'source': 'input connector',
                                     'destination': 'A',
-                                    'sourceProperty': 'inner_input',
-                                    'destinationProperty': 'param',
+                                    'dataFlow': {
+                                        'inner_input': 'param'
+                                        }
                                 }, {
                                     'source': 'A',
                                     'destination': 'output connector',
-                                    'sourceProperty': 'result',
-                                    'destinationProperty': 'inner_output',
+                                    'dataFlow': {
+                                        'result': 'inner_output'
+                                        }
                                 },
                             ],
                         },
@@ -230,13 +238,15 @@ class NestedInputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
             {
                 'source': 'input connector',
                 'destination': 'Inner',
-                'sourceProperty': 'outer_input',
-                'destinationProperty': 'inner_input',
+                'dataFlow': {
+                    'outer_input': 'inner_input'
+                    }
             }, {
                 'source': 'Inner',
                 'destination': 'output connector',
-                'sourceProperty': 'inner_output',
-                'destinationProperty': 'outer_output',
+                'dataFlow': {
+                    'inner_output': 'outer_output'
+                    }
             },
         ],
         'inputs': {
@@ -285,13 +295,15 @@ class NestedOutputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
                                 {
                                     'source': 'input connector',
                                     'destination': 'A',
-                                    'sourceProperty': 'inner_input',
-                                    'destinationProperty': 'param',
+                                    'dataFlow': {
+                                        'inner_input': 'param'
+                                        }
                                 }, {
                                     'source': 'A',
                                     'destination': 'output connector',
-                                    'sourceProperty': 'result',
-                                    'destinationProperty': 'inner_output',
+                                    'dataFlow': {
+                                        'result': 'inner_output'
+                                        }
                                 },
                             ],
                         },
@@ -305,13 +317,15 @@ class NestedOutputConnectorIsInvalidNodeName(PostWorkflowFailure, BaseAPITest):
             {
                 'source': 'input connector',
                 'destination': 'Inner',
-                'sourceProperty': 'outer_input',
-                'destinationProperty': 'inner_input',
+                'dataFlow': {
+                    'outer_input': 'inner_input'
+                    }
             }, {
                 'source': 'Inner',
                 'destination': 'output connector',
-                'sourceProperty': 'inner_output',
-                'destinationProperty': 'outer_output',
+                'dataFlow': {
+                    'inner_output': 'outer_output'
+                    }
             },
         ],
         'inputs': {
@@ -341,13 +355,15 @@ class MissingInputs(PostWorkflowFailure, BaseAPITest):
             {
                 'source': 'input connector',
                 'destination': 'A',
-                'sourceProperty': 'in_a',
-                'destinationProperty': 'param',
+                'dataFlow': {
+                    'in_a': 'param'
+                    }
             }, {
                 'source': 'A',
                 'destination': 'output connector',
-                'sourceProperty': 'result',
-                'destinationProperty': 'out_a',
+                'dataFlow': {
+                    'result': 'out_a'
+                    }
             },
         ],
         'inputs': {

--- a/tests/api/v1/test_query_workflow.py
+++ b/tests/api/v1/test_query_workflow.py
@@ -68,8 +68,9 @@ class QueryByName(QueryWorkflow, BaseAPITest):
                 {
                     'source': 'input connector',
                     'destination': 'output connector',
-                    'sourceProperty': 'in_a',
-                    'destinationProperty': 'out_a',
+                    'dataFlow': {
+                        'in_a': 'out_a',
+                    },
                 },
             ],
             'inputs': {
@@ -83,8 +84,9 @@ class QueryByName(QueryWorkflow, BaseAPITest):
                 {
                     'source': 'input connector',
                     'destination': 'output connector',
-                    'sourceProperty': 'in_z',
-                    'destinationProperty': 'out_z',
+                    'dataFlow': {
+                        'in_z': 'out_z',
+                    },
                 },
             ],
             'inputs': {

--- a/tests/api/v1/test_roundtrip_success.py
+++ b/tests/api/v1/test_roundtrip_success.py
@@ -43,6 +43,8 @@ class RoundTripSuccess(object):
         is_ok = 1
         expected_json = self._to_json(expected).splitlines(1)
         actual_json = self._to_json(actual).splitlines(1)
+        from pprint import pprint
+        pprint(actual_json)
         for line in difflib.unified_diff(expected_json, actual_json,
                 fromfile='Expected', tofile='Actual'):
             is_ok = 0
@@ -74,18 +76,16 @@ class WorkflowWithConvergeOperation(RoundTripSuccess, BaseAPITest):
             {
                 'source': 'Converge',
                 'destination': 'output connector',
-                'sourceProperty': 'c',
-                'destinationProperty': 'result',
+                'dataFlow': {
+                    'c': 'result',
+                },
             }, {
                 'source': 'input connector',
                 'destination': 'Converge',
-                'sourceProperty': 'in_a',
-                'destinationProperty': 'a',
-            }, {
-                'source': 'input connector',
-                'destination': 'Converge',
-                'sourceProperty': 'in_b',
-                'destinationProperty': 'b',
+                'dataFlow': {
+                    'in_a': 'a',
+                    'in_b': 'b',
+                },
             },
         ],
         'inputs': {
@@ -112,13 +112,15 @@ class WorkflowWithBlockOperation(RoundTripSuccess, BaseAPITest):
             {
                 'source': 'Block',
                 'destination': 'output connector',
-                'sourceProperty': 'result',
-                'destinationProperty': 'result',
+                'dataFlow': {
+                    'result': 'result',
+                },
             }, {
                 'source': 'input connector',
                 'destination': 'Block',
-                'sourceProperty': 'in_a',
-                'destinationProperty': 'in_a',
+                'dataFlow': {
+                    'in_a': 'in_a',
+                },
             },
         ],
         'inputs': {
@@ -147,13 +149,15 @@ class SingleNodeWorkflow(RoundTripSuccess, BaseAPITest):
             {
                 'source': 'A',
                 'destination': 'output connector',
-                'sourceProperty': 'result',
-                'destinationProperty': 'out_a',
+                'dataFlow': {
+                    'result': 'out_a',
+                },
             }, {
                 'source': 'input connector',
                 'destination': 'A',
-                'sourceProperty': 'in_a',
-                'destinationProperty': 'param',
+                'dataFlow': {
+                    'in_a': 'param',
+                },
             },
         ],
         'inputs': {
@@ -176,8 +180,9 @@ class MinimalNamedWorkflow(RoundTripSuccess, BaseAPITest):
             {
                 'source': 'input connector',
                 'destination': 'output connector',
-                'sourceProperty': 'in_a',
-                'destinationProperty': 'out_a',
+                'dataFlow': {
+                    'in_a': 'out_a',
+                },
             },
         ],
         'inputs': {
@@ -234,13 +239,15 @@ class NestedWorkflowWithWebhooks(RoundTripSuccess, BaseAPITest):
                             {
                                 'source': 'A',
                                 'destination': 'output connector',
-                                'sourceProperty': 'result',
-                                'destinationProperty': 'inner_output',
+                                'dataFlow': {
+                                    'result': 'inner_output',
+                                },
                             }, {
                                 'source': 'input connector',
                                 'destination': 'A',
-                                'sourceProperty': 'inner_input',
-                                'destinationProperty': 'param',
+                                'dataFlow': {
+                                    'inner_input': 'param',
+                                },
                             },
                         ],
                     },
@@ -253,13 +260,15 @@ class NestedWorkflowWithWebhooks(RoundTripSuccess, BaseAPITest):
             {
                 'source': 'Inner',
                 'destination': 'output connector',
-                'sourceProperty': 'inner_output',
-                'destinationProperty': 'outer_output',
+                'dataFlow': {
+                    'inner_output': 'outer_output',
+                },
             }, {
                 'source': 'input connector',
                 'destination': 'Inner',
-                'sourceProperty': 'outer_input',
-                'destinationProperty': 'inner_input',
+                'dataFlow': {
+                    'outer_input': 'inner_input',
+                },
             },
         ],
         'inputs': {
@@ -294,13 +303,15 @@ class NestedWorkflow(RoundTripSuccess, BaseAPITest):
                             {
                                 'source': 'A',
                                 'destination': 'output connector',
-                                'sourceProperty': 'result',
-                                'destinationProperty': 'inner_output',
+                                'dataFlow': {
+                                    'result': 'inner_output',
+                                },
                             }, {
                                 'source': 'input connector',
                                 'destination': 'A',
-                                'sourceProperty': 'inner_input',
-                                'destinationProperty': 'param',
+                                'dataFlow': {
+                                    'inner_input': 'param',
+                                },
                             },
                         ],
                     },
@@ -313,13 +324,15 @@ class NestedWorkflow(RoundTripSuccess, BaseAPITest):
             {
                 'source': 'Inner',
                 'destination': 'output connector',
-                'sourceProperty': 'inner_output',
-                'destinationProperty': 'outer_output',
+                'dataFlow': {
+                    'inner_output': 'outer_output',
+                },
             }, {
                 'source': 'input connector',
                 'destination': 'Inner',
-                'sourceProperty': 'outer_input',
-                'destinationProperty': 'inner_input',
+                'dataFlow': {
+                    'outer_input': 'inner_input',
+                },
             },
         ],
         'inputs': {
@@ -349,13 +362,15 @@ class ParallelByTaskWorkflow(RoundTripSuccess, BaseAPITest):
             {
                 'source': 'A',
                 'destination': 'output connector',
-                'sourceProperty': 'result',
-                'destinationProperty': 'out_a',
+                'dataFlow': {
+                    'result': 'out_a',
+                },
             }, {
                 'source': 'input connector',
                 'destination': 'A',
-                'sourceProperty': 'in_a',
-                'destinationProperty': 'param',
+                'dataFlow': {
+                    'in_a': 'param',
+                },
             },
         ],
         'inputs': {
@@ -390,13 +405,15 @@ class NestedParallelByTaskWorkflow(RoundTripSuccess, BaseAPITest):
                             {
                                 'source': 'A',
                                 'destination': 'output connector',
-                                'sourceProperty': 'result',
-                                'destinationProperty': 'inner_output',
+                                'dataFlow': {
+                                    'result': 'inner_output',
+                                },
                             }, {
                                 'source': 'input connector',
                                 'destination': 'A',
-                                'sourceProperty': 'inner_input',
-                                'destinationProperty': 'param',
+                                'dataFlow': {
+                                    'inner_input': 'param',
+                                },
                             },
                         ],
                     },
@@ -409,13 +426,15 @@ class NestedParallelByTaskWorkflow(RoundTripSuccess, BaseAPITest):
             {
                 'source': 'Inner',
                 'destination': 'output connector',
-                'sourceProperty': 'inner_output',
-                'destinationProperty': 'outer_output',
+                'dataFlow': {
+                    'inner_output': 'outer_output',
+                },
             }, {
                 'source': 'input connector',
                 'destination': 'Inner',
-                'sourceProperty': 'outer_input',
-                'destinationProperty': 'inner_input',
+                'dataFlow': {
+                    'outer_input': 'inner_input',
+                },
             },
         ],
         'inputs': {

--- a/tests/api/v1/test_webhooks.py
+++ b/tests/api/v1/test_webhooks.py
@@ -115,13 +115,15 @@ class NestedWorkflowWithWebhooks(WebhookTest, BaseAPITest):
                                     {
                                         'source': 'A',
                                         'destination': 'output connector',
-                                        'sourceProperty': 'param',
-                                        'destinationProperty': 'inner_output',
+                                        'dataFlow': {
+                                            'param': 'inner_output'
+                                            }
                                         }, {
                                             'source': 'input connector',
                                             'destination': 'A',
-                                            'sourceProperty': 'inner_input',
-                                            'destinationProperty': 'param',
+                                            'dataFlow': {
+                                                'inner_input': 'param'
+                                                }
                                             },
                                         ],
                                 },
@@ -134,13 +136,15 @@ class NestedWorkflowWithWebhooks(WebhookTest, BaseAPITest):
                     {
                         'source': 'Inner',
                         'destination': 'output connector',
-                        'sourceProperty': 'inner_output',
-                        'destinationProperty': 'outer_output',
+                        'dataFlow': {
+                            'inner_output': 'outer_output'
+                            }
                         }, {
                             'source': 'input connector',
                             'destination': 'Inner',
-                            'sourceProperty': 'outer_input',
-                            'destinationProperty': 'inner_input',
+                            'dataFlow': {
+                                'outer_input': 'inner_input'
+                                }
                             },
                         ],
             'inputs': {

--- a/tests/scripts/cat_command
+++ b/tests/scripts/cat_command
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+import os
+import requests
+import sys
+
+def patch_and_expect(execution_url, patch_data, status_code):
+    print "Sending PATCH to %s with body: %s" % (execution_url, patch_data)
+    response = requests.patch(execution_url, json=patch_data)
+    if (response.status_code != status_code):
+        print "Expected status_code %s, but recieved %s instead." % response.status_code
+        sys.exit(3)
+    else:
+        return response.json;
+
+def main():
+    execution_url = os.environ['PTERO_WORKFLOW_EXECUTION_URL']
+    print "Found PTERO_WORKFLOW_EXECUTION_URL = %s" % execution_url
+
+    execution_data = requests.get(execution_url).json()
+    print "Found execution_data from GET request = %s" % execution_data
+    inputs = execution_data['inputs']
+
+    values = [inputs[name] for name in sorted(inputs.keys())]
+
+    patch_data = {'outputs': {'result': ''.join(values)}}
+    patch_and_expect(execution_url, patch_data, 200)
+
+    sys.exit(os.EX_OK)
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/create_delete_file_command
+++ b/tests/scripts/create_delete_file_command
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+# deletes <filename> if input is provided, else creates a temp file and sets
+# that as the output named <filename>
+
+import os
+import requests
+import sys
+import tempfile
+
+
+def patch_and_expect(execution_url, patch_data, status_code):
+    print "Sending PATCH to %s with body: %s" % (execution_url, patch_data)
+    response = requests.patch(execution_url, json=patch_data)
+    if (response.status_code != status_code):
+        print "Expected status_code %s, but recieved %s instead." % response.status_code
+        sys.exit(3)
+    else:
+        return response.json;
+
+def main():
+    execution_url = os.environ['PTERO_WORKFLOW_EXECUTION_URL']
+    print "Found PTERO_WORKFLOW_EXECUTION_URL = %s" % execution_url
+
+    execution_data = requests.get(execution_url).json()
+    print "Found execution_data from GET request = %s" % execution_data
+    inputs = execution_data['inputs']
+
+    if 'filename' in inputs:
+        filename = inputs['filename']
+        if os.path.isfile(filename):
+            os.remove(filename)
+        else:
+            print "Expected file (%s) to exist but it doesn't" % filename
+            sys.exit(3)
+    else:
+        temp_file = tempfile.NamedTemporaryFile(delete=False)
+        patch_data = {'outputs': {'filename':temp_file.name}}
+        patch_and_expect(execution_url, patch_data, 200)
+
+    sys.exit(os.EX_OK)
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_workflow_petri_translation.py
+++ b/tests/test_workflow_petri_translation.py
@@ -46,14 +46,16 @@ class TestWorkflowPetriTranslation(unittest.TestCase):
                 {
                     'source': 'input connector',
                     'destination': 'A',
-                    'sourceProperty': 'in_a',
-                    'destinationProperty': 'param'
+                    'dataFlow': {
+                        'in_a': 'param',
+                    },
                 },
                 {
                     'source': 'A',
                     'destination': 'output connector',
-                    'sourceProperty': 'param',
-                    'destinationProperty': 'out_a'
+                    'dataFlow': {
+                        'param': 'out_a',
+                    },
                 }
             ],
 


### PR DESCRIPTION
This PR adds support for linking tasks in a DAG without any inputs/outputs.  This is useful for when you want a task to run before or after another but don't want to pass along some dummy input/output.

Closes #165 