### PR TITLE
Track spawned workflows

### DIFF
--- a/ptero_workflow/api/v1/schemas/post_workflow.json
+++ b/ptero_workflow/api/v1/schemas/post_workflow.json
@@ -4,6 +4,11 @@
 
     "type": "object",
     "properties": {
+        "parentExecutionUrl": {
+            "type": "string",
+            "description": "OPTIONAL: The url of the execution that spawned this workflow.",
+            "format": "uri"
+        },
         "inputs": { "type": "object" },
         "tasks": { "$ref": "#/definitions/taskDictionary" },
         "links": { "$ref": "#/definitions/linkList" },

--- a/ptero_workflow/api/v1/utils.py
+++ b/ptero_workflow/api/v1/utils.py
@@ -1,0 +1,28 @@
+# Taken from https://gist.github.com/miguelgrinberg/9908687
+from flask.globals import _app_ctx_stack, _request_ctx_stack
+from werkzeug.urls import url_parse
+from werkzeug.exceptions import NotFound
+
+
+def split_url(url, method=None):
+    appctx = _app_ctx_stack.top
+    reqctx = _request_ctx_stack.top
+    if appctx is None:
+        raise RuntimeError('Attempted to match a URL without the '
+                           'application context being pushed. This has to be '
+                           'executed when application context is available.')
+
+    if reqctx is not None:
+        url_adapter = reqctx.url_adapter
+    else:
+        url_adapter = appctx.url_adapter
+        if url_adapter is None:
+            raise RuntimeError('Application was not able to create a URL '
+                               'adapter for request independent URL matching. '
+                               'You might be able to fix this by setting '
+                               'the SERVER_NAME config variable.')
+    parsed_url = url_parse(url)
+    if parsed_url.netloc is not '' and \
+                    parsed_url.netloc != url_adapter.server_name:
+        raise NotFound()
+    return url_adapter.match(parsed_url.path, method)

--- a/ptero_workflow/implementation/models/execution/execution_base.py
+++ b/ptero_workflow/implementation/models/execution/execution_base.py
@@ -114,6 +114,9 @@ class Execution(Base):
         result['status_history'] = [h.as_dict(detailed=detailed)
                 for h in self.ordered_status_history]
 
+        if self.child_workflow_urls:
+            result['childWorkflowUrls'] = self.child_workflow_urls
+
         if not detailed:
             result['inputs'] = self.get_inputs()
             result['outputs'] = self.get_outputs()
@@ -135,7 +138,14 @@ class Execution(Base):
 
         result['detailsUrl'] = self.url
 
+        if self.child_workflow_urls:
+            result['childWorkflowUrls'] = self.child_workflow_urls
+
         return result
+
+    @property
+    def child_workflow_urls(self):
+        return []
 
     def update(self, update_data):
         old_data = self.as_dict(detailed=False)

--- a/ptero_workflow/implementation/models/execution/method_execution.py
+++ b/ptero_workflow/implementation/models/execution/method_execution.py
@@ -21,6 +21,10 @@ class MethodExecution(Execution):
     def parent(self):
         return self.method
 
+    @property
+    def child_workflow_urls(self):
+        return [w.url for w in self.child_workflows]
+
     def get_inputs(self):
         return self.method.task.get_inputs(colors=self.colors,
                 begins=self.begins)

--- a/ptero_workflow/implementation/models/methods/method_base.py
+++ b/ptero_workflow/implementation/models/methods/method_base.py
@@ -144,6 +144,10 @@ class Method(Base):
         return url_for('execution-detail', execution_id=execution_id,
                 _external=True)
 
+    @property
+    def workflow_submit_url(self):
+        return url_for('workflow-list', _external=True)
+
     def create_input_sources(self, session, parallel_depths):
         pass
 

--- a/ptero_workflow/implementation/models/methods/shell_command.py
+++ b/ptero_workflow/implementation/models/methods/shell_command.py
@@ -182,6 +182,7 @@ class ShellCommand(Method):
 
         submit_data['environment'].update({
             'PTERO_WORKFLOW_EXECUTION_URL': self.execution_url(execution_id),
+            'PTERO_WORKFLOW_SUBMIT_URL': self.workflow_submit_url,
         })
 
         submit_data.update({

--- a/ptero_workflow/implementation/models/webhook.py
+++ b/ptero_workflow/implementation/models/webhook.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 import celery
 import logging
 from ptero_common.statuses import succeeded, failed, canceled, errored
+from ptero_common.utils import format_dict_of_lists
 
 LOG = logging.getLogger(__name__)
 
@@ -63,14 +64,7 @@ def get_sorted_webhook_dict(entity):
     for webhook in entity.webhooks:
         unsorted_webhook_dict[webhook.name].append(webhook.url)
 
-    sorted_webhook_dict = {}
-    for name, unsorted_urls in unsorted_webhook_dict.iteritems():
-        if len(unsorted_urls) == 1:
-            entry = unsorted_urls.pop()
-        else:
-            entry = sorted(unsorted_urls)
-        sorted_webhook_dict[name] = entry
-    return sorted_webhook_dict
+    return format_dict_of_lists(unsorted_webhook_dict)
 
 def get_webhooks_for_task(task, name):
     s = object_session(task)

--- a/ptero_workflow/implementation/models/workflow.py
+++ b/ptero_workflow/implementation/models/workflow.py
@@ -1,4 +1,5 @@
 from .base import Base
+from flask import url_for
 from sqlalchemy import Column, ForeignKey, Integer, Text
 from sqlalchemy.orm import backref, relationship
 import base64
@@ -37,6 +38,12 @@ class Workflow(Base):
 
     root_task = relationship('Task', post_update=True,
             foreign_keys=[root_task_id], lazy='joined')
+
+    parent_execution_id = Column(Integer, ForeignKey('execution.id'),
+            nullable=True, index=True)
+    parent_execution = relationship('MethodExecution',
+            backref='child_workflows',
+            foreign_keys=[parent_execution_id])
 
     start_place_name = 'workflow-start-place'
 
@@ -80,6 +87,10 @@ class Workflow(Base):
         else:
             for task in self.all_tasks:
                 task.cancel()
+
+    @property
+    def url(self):
+        return url_for('workflow-detail', workflow_id=self.id, _external=True)
 
     def get_webhooks(self, *args, **kwargs):
         return self.root_task.method_list[0].get_webhooks(*args, **kwargs)

--- a/tests/api/v1/system_tests/spawned_simple_workflow/result.json
+++ b/tests/api/v1/system_tests/spawned_simple_workflow/result.json
@@ -1,0 +1,3 @@
+{
+    "outputs": null
+}

--- a/tests/api/v1/system_tests/spawned_simple_workflow/submit.json
+++ b/tests/api/v1/system_tests/spawned_simple_workflow/submit.json
@@ -1,0 +1,47 @@
+{
+    "tasks": {
+        "A": {
+            "methods": [
+                {
+                    "name": "execute",
+                    "service": "shell-command",
+                    "parameters": {
+                        "commandLine": ["./spawn_workflow_command"],
+                        "user": "{{ user }}",
+                        "workingDirectory": "{{ workingDirectory }}",
+                        "environment": {{ environment }}
+                    }
+                }
+            ]
+        }
+    },
+
+    "links": [
+        {
+            "source": "input connector",
+            "destination": "A",
+            "dataFlow": {
+                "workflow_data": "workflow_data"
+            }
+        },
+        {
+            "source": "A",
+            "destination": "output connector"
+        }
+    ],
+
+    "inputs": {
+        "workflow_data": {
+            "tasks": {
+            },
+            "links": [
+                {
+                    "source": "input connector",
+                    "destination": "output connector"
+                }
+            ],
+            "inputs": {
+            }
+        }
+    }
+}

--- a/tests/api/v1/system_tests/spawned_simple_workflow/workflow_details.json
+++ b/tests/api/v1/system_tests/spawned_simple_workflow/workflow_details.json
@@ -1,0 +1,45 @@
+{
+    "tasks": {
+        "A": {
+            "methods": [
+                {
+                    "name": "execute",
+                    "service": "shell-command",
+                    "parameters": {
+                        "commandLine": ["./echo_command"],
+                        "user": "",
+                        "workingDirectory": "",
+                        "environment": ""
+                    },
+                    "executions": {
+                        "0": { "status": "succeeded" }
+                    }
+                }
+            ],
+            "executions": {
+                "0": { "status": "succeeded" }
+            }
+        }
+    },
+
+    "links": [
+        {
+            "source": "input connector",
+            "destination": "A",
+            "dataFlow": {
+                "in_a": "param"
+            }
+        },
+        {
+            "source": "A",
+            "destination": "output connector",
+            "dataFlow": {
+                "param": "out_a"
+            }
+        }
+    ],
+
+    "inputs": {
+        "in_a": "kittens"
+    }
+}

--- a/tests/api/v1/system_tests/spawned_simple_workflow/workflow_executions.json
+++ b/tests/api/v1/system_tests/spawned_simple_workflow/workflow_executions.json
@@ -1,0 +1,190 @@
+{
+    "executions": [
+        {
+            "begins": [], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/1", 
+            "id": 1, 
+            "parentColor": null, 
+            "status": "succeeded", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-07-28 04:26:48.493272+00:00"
+                }, 
+                {
+                    "status": "succeeded", 
+                    "timestamp": "2015-07-28 04:26:51.725886+00:00"
+                }
+            ], 
+            "taskId": 2
+        }, 
+        {
+            "begins": [
+                0
+            ], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/2", 
+            "id": 2, 
+            "methodId": 1, 
+            "parentColor": null, 
+            "status": "succeeded", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-07-28 04:26:49.614574+00:00"
+                }, 
+                {
+                    "status": "scheduled", 
+                    "timestamp": "2015-07-28 04:26:49.767275+00:00"
+                }, 
+                {
+                    "status": "running", 
+                    "timestamp": "2015-07-28 04:26:49.767275+00:00"
+                }, 
+                {
+                    "status": "succeeded", 
+                    "timestamp": "2015-07-28 04:26:51.681993+00:00"
+                }
+            ]
+        }, 
+        {
+            "begins": [
+                0
+            ], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/3", 
+            "id": 3, 
+            "parentColor": null, 
+            "status": "succeeded", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-07-28 04:26:49.702737+00:00"
+                }, 
+                {
+                    "status": "scheduled", 
+                    "timestamp": "2015-07-28 04:26:49.702737+00:00"
+                }, 
+                {
+                    "status": "running", 
+                    "timestamp": "2015-07-28 04:26:49.702737+00:00"
+                }, 
+                {
+                    "status": "succeeded", 
+                    "timestamp": "2015-07-28 04:26:49.889746+00:00"
+                }
+            ], 
+            "taskId": 4
+        }, 
+        {
+            "begins": [
+                0
+            ], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/4", 
+            "id": 4, 
+            "parentColor": null, 
+            "status": "succeeded", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-07-28 04:26:49.934389+00:00"
+                }, 
+                {
+                    "status": "scheduled", 
+                    "timestamp": "2015-07-28 04:26:49.934389+00:00"
+                }, 
+                {
+                    "status": "running", 
+                    "timestamp": "2015-07-28 04:26:49.934389+00:00"
+                }, 
+                {
+                    "status": "succeeded", 
+                    "timestamp": "2015-07-28 04:26:51.091295+00:00"
+                }
+            ], 
+            "taskId": 6
+        }, 
+        {
+            "begins": [
+                0
+            ], 
+            "childWorkflowUrls": [
+                "http://localhost:7000/v1/workflows/2"
+            ], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/5", 
+            "id": 5, 
+            "methodId": 2, 
+            "parentColor": null, 
+            "status": "succeeded", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-07-28 04:26:50.004432+00:00"
+                }, 
+                {
+                    "status": "scheduled", 
+                    "timestamp": "2015-07-28 04:26:50.079270+00:00"
+                }, 
+                {
+                    "status": "running", 
+                    "timestamp": "2015-07-28 04:26:50.612823+00:00"
+                }, 
+                {
+                    "status": "succeeded", 
+                    "timestamp": "2015-07-28 04:26:50.954876+00:00"
+                }
+            ]
+        }, 
+        {
+            "begins": [
+                0
+            ], 
+            "color": 0, 
+            "colors": [
+                0
+            ], 
+            "detailsUrl": "http://localhost:7000/v1/executions/7", 
+            "id": 7, 
+            "parentColor": null, 
+            "status": "succeeded", 
+            "statusHistory": [
+                {
+                    "status": "new", 
+                    "timestamp": "2015-07-28 04:26:51.185401+00:00"
+                }, 
+                {
+                    "status": "scheduled", 
+                    "timestamp": "2015-07-28 04:26:51.185401+00:00"
+                }, 
+                {
+                    "status": "running", 
+                    "timestamp": "2015-07-28 04:26:51.185401+00:00"
+                }, 
+                {
+                    "status": "succeeded", 
+                    "timestamp": "2015-07-28 04:26:51.554558+00:00"
+                }
+            ], 
+            "taskId": 5
+        }
+    ], 
+    "updateUrl": "http://localhost:7000/v1/reports/workflow-executions?workflow_id=1&since=2015-07-28+04%3A26%3A51.725886"
+}

--- a/tests/api/v1/system_tests/spawned_simple_workflow/workflow_skeleton.json
+++ b/tests/api/v1/system_tests/spawned_simple_workflow/workflow_skeleton.json
@@ -1,0 +1,19 @@
+{
+    "id": 1, 
+    "name": "PGH4ptKETuax1FD2MreSaQ", 
+    "rootTaskId": 2, 
+    "status": "succeeded", 
+    "tasks": {
+        "A": {
+            "id": 6, 
+            "methods": [
+                {
+                    "id": 2, 
+                    "name": "execute", 
+                    "service": "shell-command"
+                }
+            ], 
+            "topologicalIndex": 0
+        }
+    }
+}

--- a/tests/scripts/spawn_workflow_command
+++ b/tests/scripts/spawn_workflow_command
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import os
+import requests
+import sys
+
+def main():
+    execution_url = os.environ['PTERO_WORKFLOW_EXECUTION_URL']
+    print "Found PTERO_WORKFLOW_EXECUTION_URL = %s" % execution_url
+
+    execution_data = requests.get(execution_url).json()
+    print "Found execution_data from GET request = %s" % execution_data
+    inputs = execution_data['inputs']
+
+    submit_url = os.environ['PTERO_WORKFLOW_SUBMIT_URL']
+    print "Found PTERO_WORKFLOW_SUBMIT_URL = %s" % submit_url
+    workflow_data = inputs['workflow_data']
+    workflow_data['parentExecutionUrl'] = execution_url
+
+    post_response = requests.post(submit_url, json=workflow_data)
+    if (post_response.status_code != 201):
+        print "Expected status_code 201, but recieved %s instead." % post_response.status_code
+        sys.exit(3)
+    workflow_url = post_response.headers['location']
+
+    updated_execution_data = requests.get(execution_url).json()
+    if 'childWorkflowUrls' not in updated_execution_data:
+        print "Expected 'childWorkflowUrl' in response to GET %s." % execution_url
+        sys.exit(3)
+    if updated_execution_data['childWorkflowUrls'] != [workflow_url]:
+        print "Expected 'childWorkflowUrl' to be '%s'" % str([workflow_url])
+        sys.exit(3)
+
+    sys.exit(os.EX_OK)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This does not implement blocking on spawned workflow completion or using
the spawned workflow's outputs in any way, it only tracks that a method
spawned a workflow.  It is 'opt-in' in the sense that you don't have to
specify the 'parentExecutionUrl' if you don't want to, although I
suspect our perlSDK will always do so if it finds it in the environment.

Closes #91 