### PR TITLE
Add indexes to improve performance

### DIFF
--- a/ptero_workflow/alembic/versions/1f093e84c2b5_execution_indexes.py
+++ b/ptero_workflow/alembic/versions/1f093e84c2b5_execution_indexes.py
@@ -1,0 +1,30 @@
+"""execution_indexes
+
+Revision ID: 1f093e84c2b5
+Revises: 2d1583cea240
+Create Date: 2015-09-06 02:58:51.574150
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1f093e84c2b5'
+down_revision = '2d1583cea240'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_index(op.f('ix_execution_status'), 'execution', ['status'], unique=False)
+    op.create_index(op.f('ix_execution_type'), 'execution', ['type'], unique=False)
+    op.create_index(op.f('ix_execution_status_history_execution_id'), 'execution_status_history', ['execution_id'], unique=False)
+    op.create_index(op.f('ix_execution_status_history_timestamp'), 'execution_status_history', ['timestamp'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_execution_status_history_timestamp'), table_name='execution_status_history')
+    op.drop_index(op.f('ix_execution_status_history_execution_id'), table_name='execution_status_history')
+    op.drop_index(op.f('ix_execution_type'), table_name='execution')
+    op.drop_index(op.f('ix_execution_status'), table_name='execution')

--- a/ptero_workflow/implementation/models/execution/execution_base.py
+++ b/ptero_workflow/implementation/models/execution/execution_base.py
@@ -32,7 +32,7 @@ class Execution(Base):
             index=True, nullable=True)
     task_id = Column(Integer, ForeignKey('task.id'),
             index=True, nullable=True)
-    _status = Column('status', Text, nullable=False)
+    _status = Column('status', Text, index=True, nullable=False)
 
     data = Column(MutableJSONDict, nullable=False)
     colors = Column(JSON)
@@ -42,7 +42,7 @@ class Execution(Base):
         nullable=False, index=True)
     workflow = relationship('Workflow', foreign_keys=[workflow_id])
 
-    type = Column(String, nullable=False)
+    type = Column(String, index=True, nullable=False)
     __mapper_args__ = {
             'polymorphic_on': 'type',
     }
@@ -186,10 +186,11 @@ class ExecutionStatusHistory(Base):
     __tablename__ = 'execution_status_history'
 
     id = Column(Integer, primary_key=True)
-    execution_id = Column(Integer, ForeignKey('execution.id'), nullable=False)
+    execution_id = Column(Integer, ForeignKey('execution.id'), 
+            index=True, nullable=False)
 
     timestamp = Column(DateTime(timezone=True), default=func.now(),
-            nullable=False)
+            index=True, nullable=False)
 
     status = Column(Text, index=True, nullable=False)
 


### PR DESCRIPTION
Using the postgres contrib 'pg_stat_statements' module, I was able to
determine what the cause of our performance degradation was:

```
ptero_workflow=# SELECT query, total_time, calls, total_time/calls as
time_per_call, rows/calls as rows_per_call FROM pg_stat_statements
ORDER BY time_per_call;
```

```
query         | SELECT execution_status_history.id AS
execution_status_history_id, execution_status_history.execution_id AS
execution_status_history_execution_id, execution_statu
s_history.timestamp AS execution_status_history_timestamp,
execution_status_history.status AS execution_status_history_status
              | FROM execution_status_history
              | WHERE ? = execution_status_history.execution_id ORDER
BY execution_status_history.timestamp
total_time    | 5094.504
calls         | 309
time_per_call | 16.487067961165
rows_per_call | 3
```

Then using the EXPLAIN command, I was able to spot the missing index:

```
ptero_workflow=# EXPLAIN SELECT execution_status_history.id AS
execution_status_history_id, execution_status_history.execution_id AS
execution_status_history_execution_id, execution_status_history.timestamp AS
execution_status_history_timestamp,
execution_status_history.status AS execution_status_history_status FROM
execution_status_history WHERE 1 = execution_status_history.execution_id
ORDER BY
execution_status_history.timestamp;
```

```
-[ RECORD 1 ]----------------------------------------------
QUERY PLAN | Sort  (cost=4583.27..4583.28 rows=4 width=23)
-[ RECORD 2 ]----------------------------------------------
QUERY PLAN |   Sort Key: "timestamp"
-[ RECORD 3 ]----------------------------------------------
QUERY PLAN |   ->  Seq Scan on execution_status_history
(cost=0.00..4583.23 rows=4 width=23)
-[ RECORD 4 ]----------------------------------------------
QUERY PLAN |         Filter: (5 = execution_id)
```

After adding these indexes, which were added based on other similar
explain statements, the performance degradation was no longer
observable