### PR TITLE
Store less data on executions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python: "2.7"
 addons:
     postgresql: "9.3"
 
-install: pip install tox
+install: pip install tox==2.1.1
 
 before_script:
     - sudo update-alternatives --install /bin/sh sh /bin/bash 100

--- a/ptero_workflow/implementation/models/methods/job.py
+++ b/ptero_workflow/implementation/models/methods/job.py
@@ -83,7 +83,7 @@ class Job(Method):
             try:
                 job_id = self._submit_to_job_service(colors, begins, execution)
                 execution.status = scheduled
-                execution.data['job_id'] = job_id
+                execution.data['jobId'] = job_id
             except Exception as e:
                 LOG.exception(
                         'Failed to submit job to service. Execution id: %s'
@@ -233,7 +233,7 @@ class Job(Method):
         return result;
 
     def validate_source(self, request_body_data, execution):
-        if execution.data['job_id'] != request_body_data['jobId']:
+        if execution.data['jobId'] != request_body_data['jobId']:
             raise exceptions.DuplicateJobError('Job from service (%s) '
                     'with id (%s) does not match submitted job id (%s)',
-                    execution.data['job_id'], request_body_data['jobId'])
+                    execution.data['jobId'], request_body_data['jobId'])

--- a/ptero_workflow/implementation/models/methods/job.py
+++ b/ptero_workflow/implementation/models/methods/job.py
@@ -81,11 +81,11 @@ class Job(Method):
             begins = group.get('begin_lineage', []) + [group['begin']]
 
             try:
-                job_id = self._submit_to_job_service(colors, begins, execution)
+                job_id, job_url = self._submit_to_job_service(colors,
+                        begins, execution)
                 execution.status = scheduled
                 execution.data['jobId'] = job_id
-                execution.data['jobUrl'] = "%s/%s" % (
-                        self._job_submit_url, job_id)
+                execution.data['jobUrl'] = job_url
             except Exception as e:
                 LOG.exception(
                         'Failed to submit job to service. Execution id: %s'
@@ -181,7 +181,8 @@ class Job(Method):
                 **body_data)
         response_info = result.wait()
         if 'json' in response_info:
-            return response_info['json']['jobId']
+            return (response_info['json']['jobId'],
+                    response_info['headers']['location'])
         else:
             raise RuntimeError("Cannot submit to job service.\n"
                 "URL: %s\nResponse info: %s" % (self._job_submit_url,

--- a/ptero_workflow/implementation/models/methods/job.py
+++ b/ptero_workflow/implementation/models/methods/job.py
@@ -84,6 +84,8 @@ class Job(Method):
                 job_id = self._submit_to_job_service(colors, begins, execution)
                 execution.status = scheduled
                 execution.data['jobId'] = job_id
+                execution.data['jobUrl'] = "%s/%s" % (
+                        self._job_submit_url, job_id)
             except Exception as e:
                 LOG.exception(
                         'Failed to submit job to service. Execution id: %s'
@@ -126,7 +128,6 @@ class Job(Method):
             self.errored(body_data, query_string_data)
         else:
             execution.status = succeeded
-            execution.data.update(body_data)
 
             s = object_session(self)
             s.commit()
@@ -144,7 +145,6 @@ class Job(Method):
         self.validate_source(body_data, execution)
 
         execution.status = failed
-        execution.data.update(body_data)
 
         s = object_session(self)
         s.commit()
@@ -161,7 +161,6 @@ class Job(Method):
         self.validate_source(body_data, execution)
 
         execution.status = errored
-        execution.data.update(body_data)
 
         s = object_session(self)
         s.commit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+http://github.com/genome/ptero-common.git@43b9503#egg=ptero_common
+-e git+http://github.com/genome/ptero-common.git@aab4bbb#egg=ptero_common
 alembic == 0.7.7
 celery == 3.1.18
 flake8


### PR DESCRIPTION
This PR makes it so that we delegate to the service to find job metadata.  To make this easier, we store the 'jobUrl' so it doesn't have to be constructed by a client.

closes #207 
closes #158 