### PR TITLE
Sleep after workflow fails before checking details

### DIFF
--- a/tests/api/v1/generator/base_case.py
+++ b/tests/api/v1/generator/base_case.py
@@ -10,6 +10,7 @@ import time
 import logging
 import difflib
 import re
+import time
 from tests.util import lsf_url, shell_command_url
 
 
@@ -85,6 +86,7 @@ class TestCaseMixin(object):
             self._verify_result(outputs_report_url)
         else:
             LOG.info("Workflow failed... Checking expected details")
+            time.sleep(2)
 
             details_url = workflow_data['reports']['workflow-details']
             self._regenerate_details_data(details_url)


### PR DESCRIPTION
I am generally very much opposed to sleeping to wait for things to
happen when it is avoidable.  In this case, the workflow's status is
'failed' but the step that caused the failure was 'parallel-by' and some
of the jobs finish *after* the workflow's status is set to failed.