### PR TITLE
Workflow status gets updated from 'new'

### DIFF
--- a/ptero_workflow/implementation/backend.py
+++ b/ptero_workflow/implementation/backend.py
@@ -102,8 +102,9 @@ class Backend(object):
         workflow.root_task = tasks.build_task('root', root_data, workflow)
         workflow.root_task.topological_index=-1
 
-        models.TaskExecution(task=workflow.root_task, color=0, parent_color=None,
-                colors=[0], begins=[], workflow=workflow, data={})
+        models.MethodExecution(method=workflow.root_task.method_list[0],
+                color=0, parent_color=None, colors=[0],
+                begins=[], workflow=workflow, data={})
 
         tasks.create_input_holder(workflow.root_task, workflow, workflow_data['inputs'],
                 color=workflow.color, parent_color=workflow.parent_color)

--- a/ptero_workflow/implementation/models/methods/method_base.py
+++ b/ptero_workflow/implementation/models/methods/method_base.py
@@ -171,6 +171,13 @@ class Method(Base):
         }
         return result
 
+    def status(self, color):
+        try:
+            return self.executions[color].status
+        except KeyError:
+            # if method hasn't created any Executions of this color yet
+            return None
+
     def cancel(self):
         LOG.info("Canceling method ID:NAME (%s:%s) of task (%s:%s)",
             self.id, self.name, self.task.id, self.task.name,

--- a/ptero_workflow/implementation/models/methods/method_base.py
+++ b/ptero_workflow/implementation/models/methods/method_base.py
@@ -11,7 +11,11 @@ from sqlalchemy.exc import IntegrityError
 import celery
 import os
 import urllib
+from ptero_common import statuses
+from ptero_common import nicer_logging
 
+
+LOG = nicer_logging.getLogger(__name__)
 
 __all__ = ['Method']
 
@@ -166,6 +170,13 @@ class Method(Base):
             'service': self.service,
         }
         return result
+
+    def cancel(self):
+        LOG.info("Canceling method ID:NAME (%s:%s) of task (%s:%s)",
+            self.id, self.name, self.task.id, self.task.name,
+            extra={'workflowName':self.workflow.name})
+        for execution in self.executions.values():
+            execution.status = statuses.canceled
 
 
 def _get_parent_color(colors):

--- a/ptero_workflow/implementation/models/task/method_list.py
+++ b/ptero_workflow/implementation/models/task/method_list.py
@@ -70,3 +70,8 @@ class MethodList(Task):
         if self.parallel_by is not None:
             result['parallelBy'] = self.parallel_by
         return result
+
+    def cancel(self):
+        super(MethodList, self).cancel()
+        for method in self.method_list:
+            method.cancel()

--- a/ptero_workflow/implementation/models/task/task_base.py
+++ b/ptero_workflow/implementation/models/task/task_base.py
@@ -84,9 +84,9 @@ class Task(Base, PetriMixin):
                     (self.parent.id, self.parent.name)
         else:
             parent_info = ''
-        LOG.info(
-                "%s - Canceling task ID:%s with name (%s)%s",
-            self.workflow_id, self.id, self.name, parent_info)
+        LOG.info("Canceling task ID:%s with name (%s)%s",
+            self.id, self.name, parent_info,
+            extra={'workflowName':self.workflow.name})
         self.is_canceled = True
         for execution in self.executions.values():
             execution.status = statuses.canceled

--- a/ptero_workflow/implementation/models/workflow.py
+++ b/ptero_workflow/implementation/models/workflow.py
@@ -67,7 +67,7 @@ class Workflow(Base):
 
     @property
     def status(self):
-        return self.root_task.status(color=self.color)
+        return self.root_task.method_list[0].status(color=self.color)
 
     @property
     def executions(self):


### PR DESCRIPTION
In order to make sure the tests pass, we first had to make sure Methods were getting canceled.  After that, it is safe to delegate to the DAG method on the root Task instead of to the root Task itself for Workflow status.