### PR TITLE
Run shell-command purge-backends before submodule update test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -111,6 +111,7 @@ commands =
     rm -rf {toxinidir}/var
     sudo rabbitmq-plugins disable rabbitmq_management
     {toxinidir}/{env:PTERO_LSF_HOME:../lsf}/scripts/purge-backends --postgres
+    {toxinidir}/{env:PTERO_SHELL_COMMAND_HOME:../shell-command}/scripts/purge-backends --postgres
     {toxinidir}/scripts/purge-backends --postgres
     devserver --procfile {toxinidir}/tests/scripts/Procfile-for-lsf-with-backing-services {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -110,8 +110,6 @@ commands =
     find {toxinidir}/ptero_workflow -name '*.pyc' -delete
     rm -rf {toxinidir}/var
     sudo rabbitmq-plugins disable rabbitmq_management
-    {toxinidir}/{env:PTERO_LSF_HOME:../lsf}/scripts/purge-backends --postgres
-    {toxinidir}/{env:PTERO_SHELL_COMMAND_HOME:../shell-command}/scripts/purge-backends --postgres
     {toxinidir}/scripts/purge-backends --postgres
     devserver --procfile {toxinidir}/tests/scripts/Procfile-for-lsf-with-backing-services {posargs}
 


### PR DESCRIPTION
This was not necessary before we had a rdbms for shell-command.  Looks
like we forgot to add this purge-backends when we introduced the
shell-command database.

I've already updated the shell script on Jenkins to include the proper database credentials.  Once this PR is merged, the next time the submodule update tests run, then the shell-command db should be purged.