### PR TITLE
Add workflow-summary report

### DIFF
--- a/ptero_workflow/api/v1/reports/__init__.py
+++ b/ptero_workflow/api/v1/reports/__init__.py
@@ -3,6 +3,7 @@ from . import workflow_executions
 from . import workflow_outputs
 from . import workflow_skeleton
 from . import workflow_status
+from . import workflow_summary
 from . import workflow_submission_data
 
 _REPORTS = {
@@ -11,6 +12,7 @@ _REPORTS = {
     'workflow-outputs': workflow_outputs.report,
     'workflow-skeleton': workflow_skeleton.report,
     'workflow-status': workflow_status.report,
+    'workflow-summary': workflow_summary.report,
     'workflow-submission-data': workflow_submission_data.report,
     }
 

--- a/ptero_workflow/api/v1/reports/workflow_summary.py
+++ b/ptero_workflow/api/v1/reports/workflow_summary.py
@@ -1,0 +1,5 @@
+from flask import g
+
+
+def report(workflow_id):
+    return g.backend.get_workflow_summary(workflow_id)

--- a/ptero_workflow/implementation/backend.py
+++ b/ptero_workflow/implementation/backend.py
@@ -286,3 +286,18 @@ class Backend(object):
                 extra={'workflowName': workflow.name})
         self.session.delete(workflow)
         self.session.commit()
+
+    def get_workflow_summary(self, workflow_id):
+        m = models
+        method_lists = self.session.query(m.MethodList).\
+                options(
+                        joinedload(m.MethodList.method_list),
+                ).filter_by(workflow_id=workflow_id).all()
+
+        dags = self.session.query(m.DAG).\
+                filter_by(workflow_id=workflow_id).all()
+
+        jobs = self.session.query(m.Job).\
+                filter_by(workflow_id=workflow_id).all()
+
+        return self._get_workflow(workflow_id).as_dict_for_summary()

--- a/ptero_workflow/implementation/models/methods/dag.py
+++ b/ptero_workflow/implementation/models/methods/dag.py
@@ -158,6 +158,15 @@ class DAG(Method):
             filter(destination_task.parent_id==self.id, source_task.parent_id==self.id).\
             order_by(source_task.name,destination_task.name).all()
 
+    def as_dict_for_summary(self):
+        result = super(DAG, self).as_dict_for_summary()
+        result['parameters'] = {
+            'tasks': {t.name: t.as_dict_for_summary()
+                for t in self.children.itervalues()
+                    if t.type not in ['InputConnector', 'OutputConnector']},
+        }
+        return result
+
     def as_skeleton_dict(self):
         result = super(DAG, self).as_skeleton_dict()
         result['parameters'] = {

--- a/ptero_workflow/implementation/models/methods/method_base.py
+++ b/ptero_workflow/implementation/models/methods/method_base.py
@@ -160,6 +160,25 @@ class Method(Base):
 
         return result
 
+    def as_dict_for_summary(self):
+        execution_summary = self.execution_summary
+        result = {
+            'executionSummary': execution_summary,
+            'name': self.name,
+            'service': self.service,
+        }
+        return result
+
+    @property
+    def execution_summary(self):
+        s = object_session(self)
+        rows = s.execute("""
+            SELECT status, count(status)
+            FROM execution WHERE method_id = :id
+            GROUP BY status;
+        """, {"id": self.id})
+        return {row[0]: row[1] for row in rows}
+
     def as_skeleton_dict(self):
         result = {
             'id': self.id,

--- a/ptero_workflow/implementation/models/task/task_base.py
+++ b/ptero_workflow/implementation/models/task/task_base.py
@@ -98,6 +98,9 @@ class Task(Base, PetriMixin):
     def as_dict(self, detailed):
         raise NotImplementedError
 
+    def as_dict_for_summary(self):
+        raise NotImplementedError
+
     def attach_transitions(self, transitions, start_place):
 
         if self.parallel_by is None:

--- a/ptero_workflow/implementation/models/workflow.py
+++ b/ptero_workflow/implementation/models/workflow.py
@@ -120,6 +120,18 @@ class Workflow(Base):
 
         return result
 
+    def as_dict_for_summary(self):
+        tasks = {name: task.as_dict_for_summary()
+            for name,task in self.tasks.iteritems()
+                if name not in ['input connector', 'output connector']}
+
+        result = {
+            'tasks': tasks,
+            'status': self.status,
+            'name': self.name,
+        }
+        return result
+
     def as_skeleton_dict(self):
         tasks = {name: task.as_skeleton_dict()
             for name,task in self.tasks.iteritems()


### PR DESCRIPTION
This 'at-a-glance' report essentially shows the workflow-skeleton with an execution summary for tasks and methods.  Below is an example on a workflow (while running) that is parallel and nested with parallel size 30 x 30.

```
$ time curl http://localhost:7000/v1/reports/workflow-summary?workflow_id=1
{
    "name": "8c953266-be55-4408-9c31-1b5a70902578",
    "status": "running",
    "tasks": {
        "DAG Task": {
            "executionSummary": {
                "running": 16,
                "succeeded": 15
            },
            "methods": [
                {
                    "executionSummary": {
                        "running": 15,
                        "succeeded": 15
                    },
                    "name": "Inner DAG",
                    "parameters": {
                        "tasks": {
                            "Job Task": {
                                "executionSummary": {
                                    "running": 464,
                                    "succeeded": 466
                                },
                                "methods": [
                                    {
                                        "executionSummary": {
                                            "running": 2,
                                            "scheduled": 446,
                                            "succeeded": 452
                                        },
                                        "name": "Echo",
                                        "service": "job"
                                    }
                                ],
                                "name": "Job Task",
                                "parallelBy": "job_in",
                                "topologicalIndex": 0
                            }
                        }
                    },
                    "service": "workflow"
                }
            ],
            "name": "DAG Task",
            "parallelBy": "dag_in",
            "topologicalIndex": 0
        }
    }
}

real    0m0.389s
user    0m0.000s
sys     0m0.007s
```