### PR TITLE
Return list of tasks instead of including topological_index

### DIFF
--- a/ptero_workflow/alembic/env.py
+++ b/ptero_workflow/alembic/env.py
@@ -3,16 +3,16 @@ from alembic import context
 from sqlalchemy import create_engine
 import os
 
-# this is the Alembic Config object, which provides
-# access to the values within the .ini file in use.
-config = context.config
-
 # add your model's MetaData object here
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
 from ptero_workflow.implementation.models.base import Base
 target_metadata = Base.metadata
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:

--- a/ptero_workflow/implementation/models/methods/dag.py
+++ b/ptero_workflow/implementation/models/methods/dag.py
@@ -160,11 +160,12 @@ class DAG(Method):
 
     def as_dict_for_summary(self):
         result = super(DAG, self).as_dict_for_summary()
-        result['parameters'] = {
-            'tasks': {t.name: t.as_dict_for_summary()
-                for t in self.children.itervalues()
-                    if t.type not in ['InputConnector', 'OutputConnector']},
-        }
+
+        sorted_tasks = sorted(self.children.values(),
+                key=lambda x: x.topological_index)
+        tasks_list = [t.as_dict_for_summary() for t in sorted_tasks
+                if t.name not in ['input connector', 'output connector']]
+        result['parameters'] = {'tasks': tasks_list}
         return result
 
     def as_skeleton_dict(self):

--- a/ptero_workflow/implementation/models/task/method_list.py
+++ b/ptero_workflow/implementation/models/task/method_list.py
@@ -70,7 +70,6 @@ class MethodList(Task):
             'executionSummary': execution_summary,
             'name': self.name,
             'methods': [m.as_dict_for_summary() for m in self.method_list],
-            'topologicalIndex': self.topological_index,
         }
         if self.parallel_by is not None:
             result['parallelBy'] = self.parallel_by

--- a/ptero_workflow/implementation/models/workflow.py
+++ b/ptero_workflow/implementation/models/workflow.py
@@ -121,12 +121,13 @@ class Workflow(Base):
         return result
 
     def as_dict_for_summary(self):
-        tasks = {name: task.as_dict_for_summary()
-            for name,task in self.tasks.iteritems()
-                if name not in ['input connector', 'output connector']}
+        sorted_tasks = sorted(self.tasks.values(),
+                key=lambda x: x.topological_index)
+        tasks_list = [t.as_dict_for_summary() for t in sorted_tasks
+                if t.name not in ['input connector', 'output connector']]
 
         result = {
-            'tasks': tasks,
+            'tasks': tasks_list,
             'status': self.status,
             'name': self.name,
         }

--- a/tox.ini
+++ b/tox.ini
@@ -84,14 +84,13 @@ commands =
     {toxinidir}/tests/scripts/run_tests {posargs}
     teardown_devserver {toxinidir}/var/run/devserver.pid
     coverage combine
-    flake8
+    flake8 {toxinidir}/ptero_workflow
 
 [testenv:dev]
 passenv = *
 commands =
     find {toxinidir}/ptero_workflow -name '*.pyc' -delete
     rm -rf {toxinidir}/var
-    {toxinidir}/scripts/purge-backends --force --postgres
     devserver --procfile {toxinidir}/tests/scripts/Procfile {posargs}
 
 [testenv:dev-all-in-one]

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ commands =
     teardown_devserver {toxinidir}/var/run/devserver.pid
     coverage combine
     coverage report
-    flake8
+    flake8 {toxinidir}/ptero_workflow
 
 [testenv:keep-db]
 passenv = *


### PR DESCRIPTION
This makes it easier to handle for the client and improves the
human-readability of the report itself too.

We may want to do this for the 'workflow-skeleton' report as well but I didn't want to alter the api of a report that clients were currently consuming.  It seems to me that topological_index should never be reported to the user, it is an implementation detail.