### PR TITLE
Change sudo to sudo -i when calling rabbitmq-plugins

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -108,7 +108,7 @@ whitelist_externals =
 commands =
     find {toxinidir}/ptero_workflow -name '*.pyc' -delete
     rm -rf {toxinidir}/var
-    sudo rabbitmq-plugins disable rabbitmq_management
+    sudo -i rabbitmq-plugins disable rabbitmq_management
     {toxinidir}/scripts/purge-backends --postgres
     devserver --procfile {toxinidir}/tests/scripts/Procfile-for-lsf-with-backing-services {posargs}
 


### PR DESCRIPTION
Alter sudo to sudo -i. Without the -i, the sudo rabbitmq-plugins call will leave an ~/.erlang.cookie file owned by root in the user's home directory. This is user 'ubuntu' when using Vagrant with a trusty VM.