### PR TITLE
Minor flake8 updates

### DIFF
--- a/ptero_workflow/implementation/models/methods/__init__.py
+++ b/ptero_workflow/implementation/models/methods/__init__.py
@@ -1,8 +1,9 @@
-from dag import *  # noqa
-from .method_base import *  # noqa
-from .job import *  # noqa
-from .block import *  # noqa
-from .converge import *  # noqa
+# flake8: noqa
+from dag import *
+from .method_base import *
+from .job import *
+from .block import *
+from .converge import *
 
 METHOD_SUBCLASSES = [DAG, Job, Block, Converge]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 -e git+http://github.com/genome/ptero-common.git@fa13bd3#egg=ptero_common
 alembic == 0.8.4
 celery == 3.1.19
-flake8
 flask == 0.10.1
 flask-restful == 0.3.5
 gunicorn == 19.4.5

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,3 +5,4 @@ psutil
 pyyaml
 requests == 2.9.1
 eventlet
+flake8 == 3.0.3

--- a/tox.ini
+++ b/tox.ini
@@ -141,6 +141,10 @@ deps =
 commands =
     ipython
 
+[testenv:flake8]
+commands =
+    flake8 {toxinidir}/ptero_workflow
+
 [flake8]
 max-line-length = 80
 exclude = *.egg,ptero_workflow/alembic/versions/*


### PR DESCRIPTION
Flake was complaining about DAG, Job, ect not being defined but they are
imported with the \* notation.

This is needed to ensure tests continue to pass with newest version of flake8.
